### PR TITLE
Use text file to read appIds

### DIFF
--- a/Testing/SamplesTest/SamplesTest/MnistTest.cs
+++ b/Testing/SamplesTest/SamplesTest/MnistTest.cs
@@ -21,7 +21,6 @@ namespace SamplesTest
         // This string key is present in RegisteredUserModeAppID under AppX/vs.appxrecipe
         // TODO: this string value has to be retrieved from local test machine
         // More information on https://github.com/Microsoft/WinAppDriver
-        private const string MNISTAppId_CS = "f330385a-7468-4688-859d-7d11a61d1b29_atz7ne7vp47fr!App";
 
         protected static WindowsDriver<WindowsElement> session;
 
@@ -30,7 +29,8 @@ namespace SamplesTest
             if (session == null)
             {
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
-                appCapabilities.SetCapability("app", MNISTAppId_CS);
+                string[] lines = System.IO.File.ReadAllLines(@".\AppIds.txt");
+                appCapabilities.SetCapability("app", lines[0]);
                 appCapabilities.SetCapability("deviceName", "WindowsPC");
                 session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session);

--- a/Testing/SamplesTest/SamplesTest/MnistTest.cs
+++ b/Testing/SamplesTest/SamplesTest/MnistTest.cs
@@ -21,6 +21,7 @@ namespace SamplesTest
         // This string key is present in RegisteredUserModeAppID under AppX/vs.appxrecipe
         // TODO: this string value has to be retrieved from local test machine
         // More information on https://github.com/Microsoft/WinAppDriver
+        private const string MNISTAppId_CS = "f330385a-7468-4688-859d-7d11a61d1b29_atz7ne7vp47fr!App";
 
         protected static WindowsDriver<WindowsElement> session;
 
@@ -29,8 +30,7 @@ namespace SamplesTest
             if (session == null)
             {
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
-                string[] lines = System.IO.File.ReadAllLines(@".\AppIds.txt");
-                appCapabilities.SetCapability("app", lines[0]);
+                appCapabilities.SetCapability("app", MNISTAppId_CS);
                 appCapabilities.SetCapability("deviceName", "WindowsPC");
                 session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session);

--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -135,6 +135,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ShowIncludes>true</ShowIncludes>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -141,7 +141,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>dxgi.lib;d3d12.lib;winml.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxgi.lib;d3d12.lib;winml.lib;windowsapp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Windows application driver requires AppID to communicate with application. This change is to read app id from a text file instead of reading hardcoded id