### PR TITLE
Add CreateDeviceOnClient and CreateDeviceInWinML flags to WinMLRunner

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -133,120 +133,240 @@ namespace WinMLRunnerTest
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceCpuBoundRGBImage)
+        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceCpuBoundBGRImage)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceCpuBoundTensor)
+        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceGpuBoundRGBImage)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceGpuBoundBGRImage)
+        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputCpuDeviceGpuBoundTensor)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceCpuBoundRGBImage)
+        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceCpuBoundBGRImage)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceCpuBoundTensor)
+        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceGpuBoundRGBImage)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceGpuBoundBGRImage)
+        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
         }
 
-        TEST_METHOD(GarbageInputGpuDeviceGpuBoundTensor)
+        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundRGBImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundRGBImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundBGRImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundBGRImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundTensor)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundTensor)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundRGBImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundRGBImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundBGRImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundBGRImage)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundTensor)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
+
+            // We need to expect one more line because of the header
+            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+        }
+
+        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundTensor)
+        {
+            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -265,6 +385,8 @@ namespace WinMLRunnerTest
                 L"-perf",
                 L"-CPU",
                 L"-GPU",
+                L"-CreateDeviceOnClient",
+                L"-CreateDeviceInWinML",
                 L"-CPUBoundInput",
                 L"-GPUBoundInput",
                 L"-RGB",
@@ -274,7 +396,7 @@ namespace WinMLRunnerTest
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(13), GetOutputCSVLineCount());
+            Assert::AreEqual(static_cast<size_t>(25), GetOutputCSVLineCount());
         }
 
         TEST_METHOD(RunAllModelsInFolderGarbageInput)
@@ -297,6 +419,8 @@ namespace WinMLRunnerTest
                 L"-perf",
                 L"-CPU",
                 L"-GPU",
+                L"-CreateDeviceOnClient",
+                L"-CreateDeviceInWinML",
                 L"-CPUBoundInput",
                 L"-GPUBoundInput",
                 L"-RGB",
@@ -306,7 +430,7 @@ namespace WinMLRunnerTest
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(25), GetOutputCSVLineCount());
+            Assert::AreEqual(static_cast<size_t>(49), GetOutputCSVLineCount());
         }
 	};
 
@@ -386,8 +510,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(TestPrintUsage)
         {
             auto const curPath = FileHelper::GetModulePath();
-            std::wstring command = curPath +
-                L"./WinMLRunner";
+            std::wstring command = curPath + L"./WinMLRunner";
             Assert::AreEqual(0, RunProc((wchar_t *)command.c_str()));
         }
     };

--- a/Tools/WinMLRunner/BindingUtilities.h
+++ b/Tools/WinMLRunner/BindingUtilities.h
@@ -5,16 +5,19 @@
 #include "ModelBinding.h"
 #include "CommandLineArgs.h"
 
-using namespace Windows::Media;
-using namespace Windows::Storage;
+using namespace winrt::Windows::Media;
+using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::AI::MachineLearning;
-using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Windows::Graphics::DirectX;
 using namespace winrt::Windows::Graphics::Imaging;
+using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
 namespace BindingUtilities
 {
+    static unsigned int seed = 0;
+    static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned int> randomBitsEngine;
+
     SoftwareBitmap GenerateGarbageImage(const TensorFeatureDescriptor& imageDescriptor, InputDataType inputDataType)
     {
         assert(inputDataType != InputDataType::Tensor);
@@ -36,8 +39,7 @@ namespace BindingUtilities
 
         // Generate random values for the image
         std::vector<uint8_t> data(totalByteSize);
-        static std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned int> randomBitsEngine;
-        randomBitsEngine.seed(static_cast<unsigned int>(time(nullptr)));
+        randomBitsEngine.seed(seed++);
         std::generate(data.begin(), data.end(), randomBitsEngine);
 
         // Write the values to a buffer
@@ -75,13 +77,16 @@ namespace BindingUtilities
         }
     }
 
-    VideoFrame CreateVideoFrame(const SoftwareBitmap& softwareBitmap, InputBindingType inputBindingType, InputDataType inputDataType)
+    VideoFrame CreateVideoFrame(const SoftwareBitmap& softwareBitmap, InputBindingType inputBindingType, InputDataType inputDataType, const IDirect3DDevice winrtDevice)
     {
         VideoFrame inputImage = VideoFrame::CreateWithSoftwareBitmap(softwareBitmap);
 
         if (inputBindingType == InputBindingType::GPU)
         {
-            VideoFrame gpuImage = VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType), softwareBitmap.PixelWidth(), softwareBitmap.PixelHeight());
+            VideoFrame gpuImage = winrtDevice
+                ? VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType), softwareBitmap.PixelWidth(), softwareBitmap.PixelHeight(), winrtDevice)
+                : VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType), softwareBitmap.PixelWidth(), softwareBitmap.PixelHeight());
+
             inputImage.CopyToAsync(gpuImage).get();
 
             return gpuImage;
@@ -254,7 +259,14 @@ namespace BindingUtilities
         throw hresult_not_implemented();
     }
 
-    ImageFeatureValue CreateBindableImage(const ILearningModelFeatureDescriptor& featureDescriptor, const std::wstring& imagePath, InputBindingType inputBindingType, InputDataType inputDataType)
+    ImageFeatureValue CreateBindableImage(
+        const ILearningModelFeatureDescriptor&
+        featureDescriptor,
+        const std::wstring& imagePath,
+        InputBindingType inputBindingType,
+        InputDataType inputDataType,
+        const IDirect3DDevice winrtDevice
+    )
     {
         auto imageDescriptor = featureDescriptor.try_as<TensorFeatureDescriptor>();
 
@@ -268,13 +280,13 @@ namespace BindingUtilities
             ? GenerateGarbageImage(imageDescriptor, inputDataType)
             : LoadImageFile(imagePath.c_str(), inputDataType);
 
-        auto videoFrame = CreateVideoFrame(softwareBitmap, inputBindingType, inputDataType);
+        auto videoFrame = CreateVideoFrame(softwareBitmap, inputBindingType, inputDataType, winrtDevice);
 
         return ImageFeatureValue::CreateFromVideoFrame(videoFrame);
     }
 
     template<typename K, typename V>
-    void OutputSequenceBinding(IMapView<hstring, Windows::Foundation::IInspectable> results, hstring name)
+    void OutputSequenceBinding(IMapView<hstring, winrt::Windows::Foundation::IInspectable> results, hstring name)
     {
         auto map = results.Lookup(name).as<IVectorView<IMap<K, V>>>().GetAt(0);
         auto iter = map.First();
@@ -295,7 +307,7 @@ namespace BindingUtilities
         std::cout << " " << maxKey << " " << maxVal << std::endl;
     }
 
-    void PrintEvaluationResults(const LearningModel& model, const CommandLineArgs& args, const IMapView<hstring, Windows::Foundation::IInspectable>& results)
+    void PrintEvaluationResults(const LearningModel& model, const CommandLineArgs& args, const IMapView<hstring, winrt::Windows::Foundation::IInspectable>& results)
     {
         if (args.Silent()) return;
         

--- a/Tools/WinMLRunner/BindingUtilities.h
+++ b/Tools/WinMLRunner/BindingUtilities.h
@@ -37,7 +37,7 @@ namespace BindingUtilities
         // We have to create RGBA8 or BGRA8 images, so we need 4 channels
         uint32_t totalByteSize = static_cast<uint32_t>(width) * static_cast<uint32_t>(height) * 4;
 
-        // Generate random values for the image
+        // Generate values for the image based on a seed
         std::vector<uint8_t> data(totalByteSize);
         randomBitsEngine.seed(seed++);
         std::generate(data.begin(), data.end(), randomBitsEngine);

--- a/Tools/WinMLRunner/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/CommandLineArgs.cpp
@@ -15,7 +15,8 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
-    std::cout << "  -CreateDeviceOnClient : create the device on the client and pass it to WinML (ignored when the device is not a GPU)" << std::endl;
+    std::cout << "  -CreateDeviceOnClient : create the device on the client and pass it to WinML" << std::endl;
+    std::cout << "  -CreateDeviceInWinML : create the device inside WinML" << std::endl;
     std::cout << "  -CPUBoundInput : bind the input to the CPU" << std::endl;
     std::cout << "  -GPUBoundInput : bind the input to the GPU" << std::endl;
     std::cout << "  -RGB : load the input as an RGB image" << std::endl;
@@ -56,6 +57,10 @@ CommandLineArgs::CommandLineArgs()
         else if ((_wcsicmp(args[i], L"-CreateDeviceOnClient") == 0))
         {
             m_createDeviceOnClient = true;
+        }
+        else if ((_wcsicmp(args[i], L"-CreateDeviceInWinML") == 0))
+        {
+            m_createDeviceInWinML = true;
         }
         else if ((_wcsicmp(args[i], L"-iterations") == 0) && (i + 1 < numArgs))
         {

--- a/Tools/WinMLRunner/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/CommandLineArgs.cpp
@@ -15,6 +15,7 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
+    std::cout << "  -CreateDeviceOnClient : create the device on the client and pass it to WinML (ignored when the device is not a GPU)" << std::endl;
     std::cout << "  -CPUBoundInput : bind the input to the CPU" << std::endl;
     std::cout << "  -GPUBoundInput : bind the input to the GPU" << std::endl;
     std::cout << "  -RGB : load the input as an RGB image" << std::endl;
@@ -52,7 +53,11 @@ CommandLineArgs::CommandLineArgs()
         {
             m_useGPUMinPower = true;
         }
-        if ((_wcsicmp(args[i], L"-iterations") == 0) && (i + 1 < numArgs))
+        else if ((_wcsicmp(args[i], L"-CreateDeviceOnClient") == 0))
+        {
+            m_createDeviceOnClient = true;
+        }
+        else if ((_wcsicmp(args[i], L"-iterations") == 0) && (i + 1 < numArgs))
         {
             m_numIterations = static_cast<UINT>(_wtoi(args[++i]));
         }

--- a/Tools/WinMLRunner/CommandLineArgs.h
+++ b/Tools/WinMLRunner/CommandLineArgs.h
@@ -15,7 +15,7 @@ public:
     bool PerfCapture() const { return m_perfCapture; }
     bool EnableDebugOutput() const { return m_debug; }
     bool Silent() const { return m_silent; }
-    bool CreateDeviceInWinML() const { return m_createDeviceInWinML; }
+    bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
    
     const std::wstring& ImagePath() const { return m_imagePath; }
     const std::wstring& CsvPath() const { return m_csvData; }
@@ -54,10 +54,10 @@ public:
         return m_useCPUBoundInput || !m_useGPUBoundInput;
     }
 
-    bool CreateDeviceOnClient() const
+    bool CreateDeviceInWinML() const
     {
-        // By Default we create the device on the client if no flag is specified
-        return m_createDeviceOnClient || !m_createDeviceInWinML;
+        // By Default we create the device in WinML if no flag is specified
+        return m_createDeviceInWinML || !m_createDeviceOnClient;
     }
 
     uint32_t NumIterations() const { return m_numIterations; }

--- a/Tools/WinMLRunner/CommandLineArgs.h
+++ b/Tools/WinMLRunner/CommandLineArgs.h
@@ -9,6 +9,7 @@ public:
 
     bool UseGPUHighPerformance() const { return m_useGPUHighPerformance; }
     bool UseGPUMinPower() const { return m_useGPUMinPower; }
+    bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
     bool UseBGR() const { return m_useBGR; }
     bool UseGPUBoundInput() const { return m_useGPUBoundInput; }
     bool IgnoreFirstRun() const { return m_ignoreFirstRun; }
@@ -61,6 +62,7 @@ private:
     bool m_useGPU = false;
     bool m_useGPUHighPerformance = false;
     bool m_useGPUMinPower = false;
+    bool m_createDeviceOnClient = false;
     bool m_useRGB = false;
     bool m_useBGR = false;
     bool m_useTensor = false;

--- a/Tools/WinMLRunner/CommandLineArgs.h
+++ b/Tools/WinMLRunner/CommandLineArgs.h
@@ -9,13 +9,13 @@ public:
 
     bool UseGPUHighPerformance() const { return m_useGPUHighPerformance; }
     bool UseGPUMinPower() const { return m_useGPUMinPower; }
-    bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
     bool UseBGR() const { return m_useBGR; }
     bool UseGPUBoundInput() const { return m_useGPUBoundInput; }
     bool IgnoreFirstRun() const { return m_ignoreFirstRun; }
     bool PerfCapture() const { return m_perfCapture; }
     bool EnableDebugOutput() const { return m_debug; }
     bool Silent() const { return m_silent; }
+    bool CreateDeviceInWinML() const { return m_createDeviceInWinML; }
    
     const std::wstring& ImagePath() const { return m_imagePath; }
     const std::wstring& CsvPath() const { return m_csvData; }
@@ -54,6 +54,12 @@ public:
         return m_useCPUBoundInput || !m_useGPUBoundInput;
     }
 
+    bool CreateDeviceOnClient() const
+    {
+        // By Default we create the device on the client if no flag is specified
+        return m_createDeviceOnClient || !m_createDeviceInWinML;
+    }
+
     uint32_t NumIterations() const { return m_numIterations; }
 
 private:
@@ -63,6 +69,7 @@ private:
     bool m_useGPUHighPerformance = false;
     bool m_useGPUMinPower = false;
     bool m_createDeviceOnClient = false;
+    bool m_createDeviceInWinML = false;
     bool m_useRGB = false;
     bool m_useBGR = false;
     bool m_useTensor = false;

--- a/Tools/WinMLRunner/Common.h
+++ b/Tools/WinMLRunner/Common.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+// unknown.h needs to be inlcuded before any winrt headers
+#include <unknwn.h>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Media.h>

--- a/Tools/WinMLRunner/OutputHelper.h
+++ b/Tools/WinMLRunner/OutputHelper.h
@@ -24,30 +24,32 @@ public:
         }
     }
 
-    void PrintBindingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType) const
+    void PrintBindingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation) const
     {
         if (!m_silent)
         {
             printf(
-                "Binding (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s)...",
+                "Binding (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s)...",
                 TypeHelper::Stringify(deviceType).c_str(),
                 iteration,
                 TypeHelper::Stringify(inputBindingType).c_str(),
-                TypeHelper::Stringify(inputDataType).c_str()
+                TypeHelper::Stringify(inputDataType).c_str(),
+                TypeHelper::Stringify(deviceCreationLocation).c_str()
             );
         }
     }
 
-    void PrintEvaluatingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType) const
+    void PrintEvaluatingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation) const
     {
         if (!m_silent)
         {
             printf(
-                "Evaluating (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s)...",
+                "Evaluating (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s)...",
                 TypeHelper::Stringify(deviceType).c_str(),
                 iteration,
                 TypeHelper::Stringify(inputBindingType).c_str(),
-                TypeHelper::Stringify(inputDataType).c_str()
+                TypeHelper::Stringify(inputDataType).c_str(),
+                TypeHelper::Stringify(deviceCreationLocation).c_str()
             );
         }
     }
@@ -122,7 +124,14 @@ public:
         }
     }
 
-    void PrintResults(const Profiler<WINML_MODEL_TEST_PERF> &profiler, uint32_t numIterations, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType) const
+    void PrintResults(
+        const Profiler<WINML_MODEL_TEST_PERF> &profiler,
+        uint32_t numIterations,
+        DeviceType deviceType,
+        InputBindingType inputBindingType,
+        InputDataType inputDataType,
+        DeviceCreationLocation deviceCreationLocation
+    ) const
     {
         double loadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
         double bindTime = profiler[BIND_VALUE].GetAverage(CounterType::TIMER);
@@ -143,11 +152,12 @@ public:
 
             std::cout << std::endl;
 
-            printf("Results (device = %s, numIterations = %d, inputBinding = %s, inputDataType = %s):\n",
+            printf("Results (device = %s, numIterations = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s):\n",
                 TypeHelper::Stringify(deviceType).c_str(),
                 numIterations,
                 TypeHelper::Stringify(inputBindingType).c_str(),
-                TypeHelper::Stringify(inputDataType).c_str()
+                TypeHelper::Stringify(inputDataType).c_str(),
+                TypeHelper::Stringify(deviceCreationLocation).c_str()
             );
 
             std::cout << "  Load: " << (isnan(loadTime) ? "N/A" : std::to_string(loadTime) + "ms") << std::endl;
@@ -281,7 +291,15 @@ public:
         m_csvFileName = fileName;
     }
 
-    void WritePerformanceDataToCSV(const Profiler<WINML_MODEL_TEST_PERF> &profiler, int numIterations, std::wstring model, std::string modelBinding, std::string inputBinding, std::string inputType, bool firstRunIgnored) const
+    void WritePerformanceDataToCSV(
+        const Profiler<WINML_MODEL_TEST_PERF> &profiler,
+        int numIterations, std::wstring model,
+        std::string modelBinding,
+        std::string inputBinding,
+        std::string inputType,
+        std::string deviceCreationLocation,
+        bool firstRunIgnored
+    ) const
     {
         double loadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
         double bindTime = profiler[BIND_VALUE].GetAverage(CounterType::TIMER);
@@ -323,6 +341,7 @@ public:
                      << "Model Binding" << ","
                      << "Input Binding" << ","
                      << "Input Type" << ","
+                     << "Device Creation Location" << ","
                      << "Iterations" << ","
                      << "First Run Ignored" << ","
                      << "Load (ms)" << ","
@@ -342,6 +361,7 @@ public:
                  << modelBinding << ","
                  << inputBinding << ","
                  << inputType << ","
+                 << deviceCreationLocation << ","
                  << numIterations << ","
                  << firstRunIgnored << ","
                  << (isnan(loadTime) ? "N/A" : std::to_string(loadTime)) << ","

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -28,7 +28,8 @@ Required command-Line arguments:
 -GPU                     : Will create a session on the GPU.
 -GPUHighPerformance      : Will create a session with the most powerful GPU device available.
 -GPUMinPower             : Will create a session with GPU with the least power.
--CreateDeviceOnClient    : Will create the device on the client and explicitly pass it to WinML (ignored when the device is not a GPU). Turning this on will usually result in faster GPU runs since we avoid a cross-device copy by creating the video frame on the same device that DML uses to bind inputs.
+-CreateDeviceOnClient    : Will create the device on the client and explicitly pass it to WinML via the API. GPU runs using this flag will usually be faster than -CreateDeviceInWinML since we avoid a cross-device copy by creating the video frame on the same device that DML uses to bind inputs.
+-CreateDeviceInWinML     : Will create the device inside WinML. GPU runs using this flag will usually be slower than -CreateDeviceOnClient since we have to copy the video frame to a different device.
 -CPUBoundInput           : Will bind the input to the CPU.
 -GPUBoundInput           : Will bind the input to the GPU.
 -BGR                     : Will load the input as a BGR image.

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -28,6 +28,7 @@ Required command-Line arguments:
 -GPU                     : Will create a session on the GPU.
 -GPUHighPerformance      : Will create a session with the most powerful GPU device available.
 -GPUMinPower             : Will create a session with GPU with the least power.
+-CreateDeviceOnClient    : Will create the device on the client and explicitly pass it to WinML (ignored when the device is not a GPU). Turning this on will usually result in faster GPU runs since we avoid a cross-device copy by creating the video frame on the same device that DML uses to bind inputs.
 -CPUBoundInput           : Will bind the input to the CPU.
 -GPUBoundInput           : Will bind the input to the GPU.
 -BGR                     : Will load the input as a BGR image.

--- a/Tools/WinMLRunner/TypeHelper.h
+++ b/Tools/WinMLRunner/TypeHelper.h
@@ -9,6 +9,7 @@ enum class InputBindingType { CPU, GPU };
 enum class InputDataType { Tensor, ImageRGB, ImageBGR };
 enum class InputSourceType { ImageFile, CSVFile, GeneratedData };
 enum class DeviceType { CPU, DefaultGPU, MinPowerGPU, HighPerfGPU };
+enum class DeviceCreationLocation { WinML, ClientCode };
 
 class TypeHelper
 {
@@ -59,6 +60,17 @@ public:
         }
 
         throw "No name found for this DeviceType.";
+    }
+
+    static std::string Stringify(DeviceCreationLocation deviceCreationLocation)
+    {
+        switch (deviceCreationLocation)
+        {
+            case DeviceCreationLocation::ClientCode: return "Client Code";
+            case DeviceCreationLocation::WinML: return "WinML";
+        }
+
+        throw "No name found for this DeviceCreationLocation.";
     }
 
     static LearningModelDeviceKind GetWinmlDeviceKind(DeviceType deviceType)


### PR DESCRIPTION
@Microsoft/winml @ryanlai2 

I stumbled upon another configuration that can change the runtime: device create on the client and passed to WinML versus device created inside WinML. When the client creates the device himself and uses this device to create a video frame, and creates a session with this device, the binding will be faster on the GPU since we avoid a cross-device and cross-GPU copy.

So I added these 2 new flags, which bump the total number of configurations to 24. Even if the model is running on the CPU, creating the device on the client side can have an impact since its input might be GPU bound and will have to be tensorized. I updated the README with the new flags.

I also changed the garbage image generation to make it deterministic between runs. This will be a lot easier to debug than seeds based on the clock and it will be possible to write validation tests by using the same seeds.