### PR TITLE
Fixed bug where models would evaluate without specifying any flags

### DIFF
--- a/Tools/WinMLRunner/Main.cpp
+++ b/Tools/WinMLRunner/Main.cpp
@@ -419,14 +419,13 @@ int main(int argc, char** argv)
     {
         output.SetDefaultCSVFileName();
     }
-    
-    std::vector<DeviceType> deviceTypes = FetchDeviceTypes(args);
-    std::vector<InputBindingType> inputBindingTypes = FetchInputBindingTypes(args);
-    std::vector<InputDataType> inputDataTypes = FetchInputDataTypes(args);
-    std::vector<std::wstring> modelPaths = args.ModelPath().empty() ? GetModelsInDirectory(args, &output) : std::vector<std::wstring>(1, args.ModelPath());
 
     if (!args.ModelPath().empty() || !args.FolderPath().empty())
     {
+        std::vector<DeviceType> deviceTypes = FetchDeviceTypes(args);
+        std::vector<InputBindingType> inputBindingTypes = FetchInputBindingTypes(args);
+        std::vector<InputDataType> inputDataTypes = FetchInputDataTypes(args);
+        std::vector<std::wstring> modelPaths = args.ModelPath().empty() ? GetModelsInDirectory(args, &output) : std::vector<std::wstring>(1, args.ModelPath());
         return EvaluateModels(modelPaths, deviceTypes, inputBindingTypes, inputDataTypes, args, output);
     }
 


### PR DESCRIPTION
This change fixes a bug from recent commits where winmlrunner tries to evaluate models in the directory it's contained in without the specification of any model or folder path.