### PR TITLE
Save Per-Iteration Performance Results

### DIFF
--- a/Tools/WinMLRunner/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/CommandLineArgs.cpp
@@ -28,6 +28,7 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -output <fully qualified path>: csv file to write the perf results to" << std::endl;
     std::cout << "  -IgnoreFirstRun : ignore the first run in the perf results when calculating the average" << std::endl;
     std::cout << "  -silent: only errors are printed to the console" << std::endl;
+    std::cout << "  -savePerIterationPerf : save per iteration performance results to csv file" << std::endl;
     std::cout << "  -debug: print trace logs" << std::endl;
     std::cout << "  -autoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
 }
@@ -118,6 +119,10 @@ CommandLineArgs::CommandLineArgs()
         else if ((_wcsicmp(args[i], L"-silent") == 0))
         {
             m_silent = true;
+        }
+        else if ((_wcsicmp(args[i], L"-savePerIterationPerf") == 0))
+        {
+            m_perIterCapture = true;
         }
         else if ((_wcsicmp(args[i], L"-autoScale") == 0) && (i + 1 < numArgs))
         {

--- a/Tools/WinMLRunner/CommandLineArgs.h
+++ b/Tools/WinMLRunner/CommandLineArgs.h
@@ -15,6 +15,7 @@ public:
     bool PerfCapture() const { return m_perfCapture; }
     bool EnableDebugOutput() const { return m_debug; }
     bool Silent() const { return m_silent; }
+    bool PerIterCapture() const { return m_perIterCapture; }
     bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
     bool AutoScale() const { return m_autoScale; }
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
@@ -80,6 +81,7 @@ private:
     bool m_ignoreFirstRun = false;
     bool m_debug = false;
     bool m_silent = false;
+    bool m_perIterCapture = false;
     bool m_autoScale = false;
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
 

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -39,6 +39,7 @@ Required command-Line arguments:
 -output <CSV path>       : Path to the CSV where the perf results will be written.
 -IgnoreFirstRun          : Will ignore the first run in the perf results when calculating the average
 -silent                  : Silent mode (only errors will be printed to the console)
+-savePerIterationPerf	 : Save per iteration performance results to csv file.
 -debug                   : Will start a trace logging session.
 -autoScale <mode>        : Will automatically scale an input image to match the required input dimensions of the model.  Pass in the interpolation mode, one of ["Nearest", "Linear", "Cubic", "Fant"].
 


### PR DESCRIPTION
* Command line argument -saveiter dumps per-iteration values to csv files
* The following per-iteration values are saved in PerIterationValues.csv
   - ModelName, ImageName
   - Final Result, Hash of Output Tensor
   - CPU & GPU Memory(Diff & Start)
   - Load, Bind & Evaluate Time
* Result[FullOutputTensor].csv contains the per-iteration output tensor result