### PR TITLE
Saves Per-Iteration Performance Results

### DIFF
--- a/Tools/WinMLRunner/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/CommandLineArgs.cpp
@@ -28,6 +28,7 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -output <fully qualified path>: csv file to write the perf results to" << std::endl;
     std::cout << "  -IgnoreFirstRun : ignore the first run in the perf results when calculating the average" << std::endl;
     std::cout << "  -silent: only errors are printed to the console" << std::endl;
+    std::cout << "  -saveiter : saves per iteration performance values to csv file" << std::endl;
     std::cout << "  -debug: print trace logs" << std::endl;
     std::cout << "  -autoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
 }
@@ -118,6 +119,10 @@ CommandLineArgs::CommandLineArgs()
         else if ((_wcsicmp(args[i], L"-silent") == 0))
         {
             m_silent = true;
+        }
+        else if ((_wcsicmp(args[i], L"-saveiter") == 0))
+        {
+            m_perIterCapture = true;
         }
         else if ((_wcsicmp(args[i], L"-autoScale") == 0) && (i + 1 < numArgs))
         {

--- a/Tools/WinMLRunner/CommandLineArgs.h
+++ b/Tools/WinMLRunner/CommandLineArgs.h
@@ -15,6 +15,7 @@ public:
     bool PerfCapture() const { return m_perfCapture; }
     bool EnableDebugOutput() const { return m_debug; }
     bool Silent() const { return m_silent; }
+    bool PerIterCapture() const { return m_perIterCapture; }
     bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
     bool AutoScale() const { return m_autoScale; }
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
@@ -80,6 +81,7 @@ private:
     bool m_ignoreFirstRun = false;
     bool m_debug = false;
     bool m_silent = false;
+    bool m_perIterCapture = false;
     bool m_autoScale = false;
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
 

--- a/Tools/WinMLRunner/TimerHelper.h
+++ b/Tools/WinMLRunner/TimerHelper.h
@@ -125,6 +125,7 @@ public:
     double GetDeltaPeakPageFileUsage() { return m_deltaPeakPagefileUsage; }
     double GetDeltaWorkingSetUsage() { return m_deltaWorkingSetSize; }
     double GetDeltaPeakWorkingSetUsage() { return m_deltaPeakWorkingSetSize; }
+    double GetStartWorkingSet() { return  (double)BYTE_TO_MB((double)m_startWorkingSetSize); }
 
 private:
 
@@ -320,6 +321,7 @@ public:
     double GetGpuUsage() const { return m_gpuUsage; }
     double GetDedicatedMemory() const { return m_deltaGpuDedicatedMemory; }
     double GetSharedMemory() const { return m_deltaGpuSharedMemory; }
+    double GetStartSharedMemory() { return  m_startGpuSharedMemory; }
 
 private:
     // Pdh function prototypes
@@ -390,6 +392,8 @@ typedef enum CounterType
     GPU_USAGE,
     GPU_DEDICATED_MEM_USAGE,
     GPU_SHARED_MEM_USAGE,
+    STARTING_WORKING_SET,
+    STARTING_SHARED_MEM,
     TYPE_COUNT
 } CounterType;
 
@@ -404,7 +408,9 @@ const static std::vector<std::wstring> CounterTypeName =
     L"PEAK WORK SET USAGE",
     L"GPU USAGE",
     L"GPU_DEDICATED_MEM_USAGE",
-    L"GPU_SHARED_MEM_USAGE"
+    L"GPU_SHARED_MEM_USAGE",
+    L"STARTING_WORKING_SET",
+    L"STARTING_SHARED_MEM"
 };
 
 class PerfCounterStatistics
@@ -475,10 +481,12 @@ public:
         counterValue[CounterType::PEAK_PAGE_FILE_USAGE] = m_cpuCounter.GetDeltaPeakPageFileUsage();
         counterValue[CounterType::WORKING_SET_USAGE] = m_cpuCounter.GetDeltaWorkingSetUsage();
         counterValue[CounterType::PEAK_WORKING_SET_USAGE] = m_cpuCounter.GetDeltaPeakWorkingSetUsage();
+        counterValue[CounterType::STARTING_WORKING_SET] = m_cpuCounter.GetStartWorkingSet();
 #ifndef DISABLE_GPU_COUNTERS
         counterValue[CounterType::GPU_USAGE] = m_gpuCounter.GetGpuUsage();
         counterValue[CounterType::GPU_DEDICATED_MEM_USAGE] = m_gpuCounter.GetDedicatedMemory();
         counterValue[CounterType::GPU_SHARED_MEM_USAGE] = m_gpuCounter.GetSharedMemory();
+        counterValue[CounterType::STARTING_SHARED_MEM] = m_gpuCounter.GetStartSharedMemory();
 #endif
         // Update data blocks
         for (int i = 0; i < CounterType::TYPE_COUNT; ++i)
@@ -499,6 +507,12 @@ public:
         {
             ++m_pos;
         }
+
+        CpuWorkingDiff = counterValue[CounterType::WORKING_SET_USAGE];
+        CpuWorkingStart = counterValue[CounterType::STARTING_WORKING_SET];
+        GpuSharedDiff = counterValue[CounterType::GPU_SHARED_MEM_USAGE];
+        GpuSharedStart = counterValue[CounterType::STARTING_SHARED_MEM];
+        GpuDedicatedDiff = counterValue[CounterType::GPU_DEDICATED_MEM_USAGE];
     }
 
     int GetCount() const { return (m_bBufferFull) ? TIMER_SLOT_SIZE : m_pos; }
@@ -521,6 +535,11 @@ public:
         }
         return var / count;
     }
+    double GetCpuWorkingDiff() { return CpuWorkingDiff; }
+    double GetGpuSharedDiff() { return GpuSharedDiff; }
+    double GetCpuWorkingStart() { return CpuWorkingStart; }
+    double GetGpuSharedStart() { return GpuSharedStart; }
+    double GetGpuDedicatedDiff() { return GpuDedicatedDiff; }
 
 private:
     struct DataBlock
@@ -549,6 +568,12 @@ private:
     GpuPerfCounter m_gpuCounter;
 #endif
     DataBlock m_data[CounterType::TYPE_COUNT];
+
+    double CpuWorkingDiff;
+    double CpuWorkingStart;
+    double GpuSharedDiff;
+    double GpuSharedStart;
+    double GpuDedicatedDiff;
 };
 
 


### PR DESCRIPTION
* Command line argument -saveiter dumps per-iteration performance values to csv file
* The following per-iteration values are saved in PerIterPerf.csv
   - ModelName, ImageName
   - Final Result, Hash of Output Tensor
   - CPU & GPU Memory (Diff & Start)
   - Load, Bind & Evaluate Time