### PR TITLE
Automatically find Squeezenet.onnx in Desktop sample, and make F5 bui…

### DIFF
--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/README.md
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/README.md
@@ -33,7 +33,7 @@ Note: SqueezeNet was trained to work with image sizes of 224x224, so you must pr
 3. Change the current folder to the folder containing the built EXE (`cd <path-to-exe>`).
 4. Run the executable as shown below. Make sure to replace the install location with what matches yours:
   ```
-  SqueezeNetObjectDetection.exe C:\Repos\Windows-Machine-Learning\SharedContent\models\SqueezeNet.onnx C:\Repos\Windows-Machine-Learning\SharedContent\media\kitten_224.png
+  SqueezeNetObjectDetection.exe C:\Repos\Windows-Machine-Learning\SharedContent\media\kitten_224.png
   ```
 5. You should get output similar to the following:
   ```

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/SqueezeNetObjectDetectionCPP.vcxproj
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/SqueezeNetObjectDetectionCPP.vcxproj
@@ -106,6 +106,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\..\SharedContent\models\SqueezeNet.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
@@ -115,22 +116,32 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="Labels.txt" />
+    <CopyFileToFolders Include="Labels.txt">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </CopyFileToFolders>
     <Text Include="readme.txt">
       <DeploymentContent>false</DeploymentContent>
     </Text>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\..\..\SharedContent\models\SqueezeNet.onnx">
+    <CopyFileToFolders Include="..\..\..\..\SharedContent\models\SqueezeNet.onnx">
       <DeploymentContent>true</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
-    </None>
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
-    <Image Include="..\..\..\..\SharedContent\media\kitten_224.png">
+    <CopyFileToFolders Include="..\..\..\..\SharedContent\media\kitten_224.png">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
@@ -139,7 +150,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
-    </Image>
+    </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/SqueezeNetObjectDetectionCPP.vcxproj.filters
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/SqueezeNetObjectDetectionCPP.vcxproj.filters
@@ -6,17 +6,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\..\SharedContent\models\SqueezeNet.onnx">
-      <Filter>SharedContent</Filter>
-    </None>
+    <ClInclude Include="..\..\..\..\SharedContent\models\SqueezeNet.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="readme.txt" />
-    <Text Include="Labels.txt">
-      <Filter>SharedContent</Filter>
-    </Text>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="SharedContent">
@@ -24,8 +17,14 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <Image Include="..\..\..\..\SharedContent\media\kitten_224.png">
+    <CopyFileToFolders Include="..\..\..\..\SharedContent\models\SqueezeNet.onnx">
       <Filter>SharedContent</Filter>
-    </Image>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\..\..\..\SharedContent\media\kitten_224.png">
+      <Filter>SharedContent</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Labels.txt">
+      <Filter>SharedContent</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -17,7 +17,6 @@ vector<string> labels;
 string labelsFileName("labels.txt");
 LearningModelDeviceKind deviceKind = LearningModelDeviceKind::Default;
 string deviceName = "default";
-hstring modelPath;
 hstring imagePath;
 
 // helper functions
@@ -26,6 +25,14 @@ void LoadLabels();
 VideoFrame LoadImageFile(hstring filePath);
 void PrintResults(IVectorView<float> results);
 bool ParseArgs(int argc, char* argv[]);
+
+wstring GetModelPath()
+{
+    wostringstream woss;
+    woss << GetModulePath().c_str();
+    woss << "SqueezeNet.onnx";
+    return woss.str();
+}
 
 // MAIN !
 // usage: SqueezeNet [modelfile] [imagefile] [cpu|directx]
@@ -39,6 +46,9 @@ int main(int argc, char* argv[])
         printf("Usage: %s [modelfile] [imagefile] [cpu|directx]", argv[0]);
         return -1;
     }
+
+    // Get model path
+    auto modelPath = GetModelPath();
 
     // load the model
     printf("Loading modelfile '%ws' on the '%s' device\n", modelPath.c_str(), deviceName.c_str());
@@ -76,18 +86,16 @@ int main(int argc, char* argv[])
 
 bool ParseArgs(int argc, char* argv[])
 {
-    if (argc < 3)
+    if (argc < 2)
     {
         return false;
     }
-    // get the model file
-    modelPath = hstring(wstring_to_utf8().from_bytes(argv[1]));
     // get the image file
-    imagePath = hstring(wstring_to_utf8().from_bytes(argv[2]));
+    imagePath = hstring(wstring_to_utf8().from_bytes(argv[1]));
     // did they pass a fourth arg?
-    if (argc >= 4)
+    if (argc >= 3)
     {
-        deviceName = argv[3];
+        deviceName = argv[2];
         if (deviceName == "cpu")
         {
             deviceKind = LearningModelDeviceKind::Cpu;
@@ -136,7 +144,7 @@ void LoadLabels()
     while (std::getline(labelFile, s, ','))
     {
         int labelValue = atoi(s.c_str());
-        if (labelValue >= labels.size())
+        if (static_cast<uint32_t>(labelValue) >= labels.size())
         {
             labels.resize(labelValue + 1);
         }

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <codecvt>
 #include <fstream>
+#include <sstream>
 
 using convert_type = std::codecvt_utf8<wchar_t>;
 using wstring_to_utf8 = std::wstring_convert<convert_type, wchar_t>;


### PR DESCRIPTION
1) Make squeezenet desktop sample work with F5 build, and automatically copy assets from the SharedContent folder into the build directory.

2) Automatically construct the squeenenet onnx model path.

3) Fix warning of signed/unsigned mismatch.