### PR TITLE
User/orilevari/top3 bug

### DIFF
--- a/Samples/AdapterSelection/AdapterSelection/cpp/README.md
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/README.md
@@ -53,7 +53,7 @@ Note: SqueezeNet was trained to work with image sizes of 224x224, so you must pr
   model run took 31 ticks
   tabby, tabby cat with confidence of 0.931461
   Egyptian cat with confidence of 0.065307
-  Persian cat with confidence of 0.000193
+  tiger cat with confidence of 0.002927
   ```
 
 

--- a/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
@@ -208,27 +208,21 @@ void PrintResults(IVectorView<float> results)
     // load the labels
     LoadLabels();
 
-    struct result {
-        float probability;
-        uint32_t index;
-    };
-    vector<result> sortedResults;
-
+    vector<pair<float, uint32_t>> sortedResults;
     for (uint32_t i = 0; i < results.Size(); i++) {
-        result curr;
-        curr.probability = results.GetAt(i);
-        curr.index = i;
+        pair<float, uint32_t> curr;
+        curr.first = results.GetAt(i);
+        curr.second = i;
         sortedResults.push_back(curr);
     }
-
     std::sort(sortedResults.begin(), sortedResults.end(),
-        [](result const &a, result const &b) { return a.probability > b.probability; });
+        [](pair<float, uint32_t> const &a, pair<float, uint32_t> const &b) { return a.first > b.first; });
 
     // Display the result
     for (int i = 0; i < 3; i++)
     {
-        result curr = sortedResults.at(i);
-        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
+        pair<float, uint32_t> curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.second].c_str(), curr.first);
     }
 }
 

--- a/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
@@ -205,30 +205,31 @@ VideoFrame LoadImageFile(hstring filePath)
 
 void PrintResults(IVectorView<float> results)
 {
-	// load the labels
-	LoadLabels();
-	// Find the top 3 probabilities
-	vector<float> topProbabilities(3);
-	vector<int> topProbabilityLabelIndexes(3);
-	// SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-	for (uint32_t i = 0; i < results.Size(); i++)
-	{
-		// is it one of the top 3?
-		for (int j = 0; j < 3; j++)
-		{
-			if (results.GetAt(i) > topProbabilities[j])
-			{
-				topProbabilityLabelIndexes[j] = i;
-				topProbabilities[j] = results.GetAt(i);
-				break;
-			}
-		}
-	}
-	// Display the result
-	for (int i = 0; i < 3; i++)
-	{
-		printf("%s with confidence of %f\n", labels[topProbabilityLabelIndexes[i]].c_str(), topProbabilities[i]);
-	}
+    // load the labels
+    LoadLabels();
+
+    struct result {
+        float probability;
+        uint32_t index;
+    };
+    vector<result> sortedResults;
+
+    for (uint32_t i = 0; i < results.Size(); i++) {
+        result curr;
+        curr.probability = results.GetAt(i);
+        curr.index = i;
+        sortedResults.push_back(curr);
+    }
+
+    std::sort(sortedResults.begin(), sortedResults.end(),
+        [](result const &a, result const &b) { return a.probability > b.probability; });
+
+    // Display the result
+    for (int i = 0; i < 3; i++)
+    {
+        result curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
+    }
 }
 
 int32_t WINRT_CALL WINRT_CoIncrementMTAUsage(void** cookie) noexcept

--- a/Samples/AdapterSelection/AdapterSelection/cpp/pch.h
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/pch.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <codecvt>
 #include <fstream>
+#include <algorithm>
 
 
 using convert_type = std::codecvt_utf8<wchar_t>;

--- a/Samples/CustomOperatorCPU/desktop/cpp/README.md
+++ b/Samples/CustomOperatorCPU/desktop/cpp/README.md
@@ -61,7 +61,7 @@ The Relu and NoisyRelu operator client code curates its own input data, but the 
   model run took 203 ticks
   tabby, tabby cat with confidence of 0.931461
   Egyptian cat with confidence of 0.065307
-  Persian cat with confidence of 0.000193
+  tiger cat with confidence of 0.002927
   ```
   Relu:
   ```

--- a/Samples/CustomOperatorCPU/desktop/cpp/main.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/main.cpp
@@ -130,27 +130,28 @@ void PrintResults(IVectorView<float> results)
 {
     // load the labels
     LoadLabels();
-    // Find the top 3 probabilities
-    vector<float> topProbabilities(3);
-    vector<int> topProbabilityLabelIndexes(3);
-    // SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-    for (uint32_t i = 0; i < results.Size(); i++)
-    {
-        // is it one of the top 3?
-        for (int j = 0; j < 3; j++)
-        {
-            if (results.GetAt(i) > topProbabilities[j])
-            {
-                topProbabilityLabelIndexes[j] = i;
-                topProbabilities[j] = results.GetAt(i);
-                break;
-            }
-        }
+
+    struct result {
+        float probability;
+        uint32_t index;
+    };
+    vector<result> sortedResults;
+
+    for (uint32_t i = 0; i < results.Size(); i++) {
+        result curr;
+        curr.probability = results.GetAt(i);
+        curr.index = i;
+        sortedResults.push_back(curr);
     }
+
+    std::sort(sortedResults.begin(), sortedResults.end(),
+        [](result const &a, result const &b) { return a.probability > b.probability; });
+
     // Display the result
     for (int i = 0; i < 3; i++)
     {
-        printf("%s with confidence of %f\n", labels[topProbabilityLabelIndexes[i]].c_str(), topProbabilities[i]);
+        result curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
     }
 }
 

--- a/Samples/CustomOperatorCPU/desktop/cpp/main.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/main.cpp
@@ -131,27 +131,21 @@ void PrintResults(IVectorView<float> results)
     // load the labels
     LoadLabels();
 
-    struct result {
-        float probability;
-        uint32_t index;
-    };
-    vector<result> sortedResults;
-
+    vector<pair<float, uint32_t>> sortedResults;
     for (uint32_t i = 0; i < results.Size(); i++) {
-        result curr;
-        curr.probability = results.GetAt(i);
-        curr.index = i;
+        pair<float, uint32_t> curr;
+        curr.first = results.GetAt(i);
+        curr.second = i;
         sortedResults.push_back(curr);
     }
-
     std::sort(sortedResults.begin(), sortedResults.end(),
-        [](result const &a, result const &b) { return a.probability > b.probability; });
+        [](pair<float, uint32_t> const &a, pair<float, uint32_t> const &b) { return a.first > b.first; });
 
     // Display the result
     for (int i = 0; i < 3; i++)
     {
-        result curr = sortedResults.at(i);
-        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
+        pair<float, uint32_t> curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.second].c_str(), curr.first);
     }
 }
 

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/README.md
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/README.md
@@ -45,7 +45,7 @@ Note: SqueezeNet was trained to work with image sizes of 224x224, so you must pr
   model run took 31 ticks
   tabby, tabby cat with confidence of 0.931461
   Egyptian cat with confidence of 0.065307
-  Persian cat with confidence of 0.000193
+  tiger cat with confidence of 0.002927
   ```
 
 ## License

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -196,7 +196,7 @@ void PrintResults(IVectorView<float> results)
     }
 
     std::sort(sortedResults.begin(), sortedResults.end(),
-        [](result const &a, result const &b) { return a.probability < b.probability; });
+        [](result const &a, result const &b) { return a.probability > b.probability; });
 
     // Display the result
     for (int i = 0; i < 3; i++)

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -187,14 +187,12 @@ void PrintResults(IVectorView<float> results)
         uint32_t index;
     };
     vector<result> sortedResults;
-
     for (uint32_t i = 0; i < results.Size(); i++) {
         result curr;
         curr.probability = results.GetAt(i);
         curr.index = i;
         sortedResults.push_back(curr);
     }
-
     std::sort(sortedResults.begin(), sortedResults.end(),
         [](result const &a, result const &b) { return a.probability > b.probability; });
 

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -181,27 +181,28 @@ void PrintResults(IVectorView<float> results)
 {
     // load the labels
     LoadLabels();
-    // Find the top 3 probabilities
-    vector<float> topProbabilities(3);
-    vector<int> topProbabilityLabelIndexes(3);
-    // SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-    for (uint32_t i = 0; i < results.Size(); i++)
-    {
-        // is it one of the top 3?
-        for (int j = 0; j < 3; j++)
-        {
-            if (results.GetAt(i) > topProbabilities[j])
-            {
-                topProbabilityLabelIndexes[j] = i;
-                topProbabilities[j] = results.GetAt(i);
-                break;
-            }
-        }
+
+    struct result {
+        float probability;
+        uint32_t index;
+    };
+    vector<result> sortedResults;
+
+    for (uint32_t i = 0; i < results.Size(); i++) {
+        result curr;
+        curr.probability = results.GetAt(i);
+        curr.index = i;
+        sortedResults.push_back(curr);
     }
+
+    std::sort(sortedResults.begin(), sortedResults.end(),
+        [](result const &a, result const &b) { return a.probability < b.probability; });
+
     // Display the result
     for (int i = 0; i < 3; i++)
     {
-        printf("%s with confidence of %f\n", labels[topProbabilityLabelIndexes[i]].c_str(), topProbabilities[i]);
+        result curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
     }
 }
 

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -182,25 +182,21 @@ void PrintResults(IVectorView<float> results)
     // load the labels
     LoadLabels();
 
-    struct result {
-        float probability;
-        uint32_t index;
-    };
-    vector<result> sortedResults;
+    vector<pair<float, uint32_t>> sortedResults;
     for (uint32_t i = 0; i < results.Size(); i++) {
-        result curr;
-        curr.probability = results.GetAt(i);
-        curr.index = i;
+        pair<float, uint32_t> curr;
+        curr.first = results.GetAt(i);
+        curr.second = i;
         sortedResults.push_back(curr);
     }
     std::sort(sortedResults.begin(), sortedResults.end(),
-        [](result const &a, result const &b) { return a.probability > b.probability; });
+        [](pair<float, uint32_t> const &a, pair<float, uint32_t> const &b) { return a.first > b.first; });
 
     // Display the result
     for (int i = 0; i < 3; i++)
     {
-        result curr = sortedResults.at(i);
-        printf("%s with confidence of %f\n", labels[curr.index].c_str(), curr.probability);
+        pair<float, uint32_t> curr = sortedResults.at(i);
+        printf("%s with confidence of %f\n", labels[curr.second].c_str(), curr.first);
     }
 }
 

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
@@ -22,6 +22,7 @@
 #include <codecvt>
 #include <fstream>
 #include <sstream>
+#include <algorithm>
 
 using convert_type = std::codecvt_utf8<wchar_t>;
 using wstring_to_utf8 = std::wstring_convert<convert_type, wchar_t>;

--- a/Samples/SqueezeNetObjectDetection/NETCore/cs/Program.cs
+++ b/Samples/SqueezeNetObjectDetection/NETCore/cs/Program.cs
@@ -128,31 +128,35 @@ namespace SqueezeNetObjectDetectionNC
             return ImageFeatureValue.CreateFromVideoFrame(inputImage);
         }
 
-
         private static void PrintResults(IReadOnlyList<float> resultVector)
         {
             // load the labels
             LoadLabels();
-            // Find the top 3 probabilities
-            List<float> topProbabilities = new List<float>() { 0.0f, 0.0f, 0.0f };
-            List<int> topProbabilityLabelIndexes = new List<int>() { 0, 0, 0 };
-            // SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-            for (int i = 0; i < resultVector.Count(); i++)
+
+            List<(int index, float probability)> indexedResults = new List<(int, float)>();
+            for (int i = 0; i < resultVector.Count; i++)
             {
-                // is it one of the top 3?
-                for (int j = 0; j < 3; j++)
-                {
-                    if (resultVector[i] > topProbabilities[j])
-                    {
-                        topProbabilityLabelIndexes[j] = i;
-                        topProbabilities[j] = resultVector[i];
-                        break;
-                    }
-                }
+                indexedResults.Add((index: i, probability: resultVector.ElementAt(i)));
             }
+            indexedResults.Sort((a, b) =>
+            {
+                if (a.probability < b.probability)
+                {
+                    return 1;
+                }
+                else if (a.probability > b.probability)
+                {
+                    return -1;
+                }
+                else
+                {
+                    return 0;
+                }
+            });
+
             for (int i = 0; i < 3; i++)
             {
-                Console.WriteLine($"\"{ _labels[topProbabilityLabelIndexes[i]]}\" with confidence of { topProbabilities[i]}");
+                Console.WriteLine($"\"{ _labels[indexedResults[i].index]}\" with confidence of { indexedResults[i].probability}");
             }
         }
     }

--- a/Samples/SqueezeNetObjectDetection/NETCore/cs/README.md
+++ b/Samples/SqueezeNetObjectDetection/NETCore/cs/README.md
@@ -44,7 +44,7 @@ The file path for the Windows.winmd file may be: ```C:\Program Files (x86)\Windo
   model run took 31 ticks
   "tabby, tabby cat" with confidence of 0.931461
   "Egyptian cat" with confidence of 0.065307
-  "Persian cat" with confidence of 0.000193
+  "tiger cat" with confidence of 0.002927
   ```
 
 ## License

--- a/Samples/SqueezeNetObjectDetection/NETCore/cs/SqueezeNetObjectDetectionNC.csproj
+++ b/Samples/SqueezeNetObjectDetection/NETCore/cs/SqueezeNetObjectDetectionNC.csproj
@@ -38,4 +38,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Labels.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Samples/SqueezeNetObjectDetection/UWP/cs/MainPage.xaml.cs
+++ b/Samples/SqueezeNetObjectDetection/UWP/cs/MainPage.xaml.cs
@@ -203,34 +203,37 @@ namespace SqueezeNetObjectDetection
                     var results = await _session.EvaluateAsync(binding, $"Run { ++_runCount } ");
 
                     ticks = Environment.TickCount - ticks;
+                    string message = $"Run took { ticks } ticks";
 
                     // retrieve results from evaluation
                     var resultTensor = results.Outputs["softmaxout_1"] as TensorFloat;
                     var resultVector = resultTensor.GetAsVectorView();
 
                     // Find the top 3 probabilities
-                    List<float> topProbabilities = new List<float>() { 0.0f, 0.0f, 0.0f };
-                    List<int> topProbabilityLabelIndexes = new List<int>() { 0, 0, 0 };
-                    // SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-                    for (int i = 0; i < resultVector.Count(); i++)
+                    List<(int index, float probability)> indexedResults = new List<(int, float)>();
+                    for (int i = 0; i < resultVector.Count; i++)
                     {
-                        // is it one of the top 3?
-                        for (int j = 0; j < 3; j++)
-                        {
-                            if (resultVector[i] > topProbabilities[j])
-                            {
-                                topProbabilityLabelIndexes[j] = i;
-                                topProbabilities[j] = resultVector[i];
-                                break;
-                            }
-                        }
+                        indexedResults.Add((index: i, probability: resultVector.ElementAt(i)));
                     }
+                    indexedResults.Sort((a, b) =>
+                    {
+                        if (a.probability < b.probability)
+                        {
+                            return 1;
+                        }
+                        else if (a.probability > b.probability)
+                        {
+                            return -1;
+                        }
+                        else
+                        {
+                            return 0;
+                        }
+                    });
 
-                    // Display the result
-                    string message = $"Run took { ticks } ticks";
                     for (int i = 0; i < 3; i++)
                     {
-                        message += $"\n\"{ _labels[topProbabilityLabelIndexes[i]]}\" with confidence of { topProbabilities[i]}";
+                        message += $"\n\"{ _labels[indexedResults[i].index]}\" with confidence of { indexedResults[i].probability}";
                     }
                     StatusBlock.Text = message;
                 }

--- a/Samples/SqueezeNetObjectDetection/UWP/cs/SqueezeNetObjectDetectionCS.csproj
+++ b/Samples/SqueezeNetObjectDetection/UWP/cs/SqueezeNetObjectDetectionCS.csproj
@@ -105,6 +105,7 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="model.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/SqueezeNetObjectDetection/UWP/js/js/main.js
+++ b/Samples/SqueezeNetObjectDetection/UWP/js/js/main.js
@@ -101,26 +101,21 @@ function pickImage() {
                             var resultTensor = results.outputs["softmaxout_1"];
                             var resultVector = resultTensor.getAsVectorView();
                             // Find the top 3 probabilities
-                            var topProbabilities = [ 0.0, 0.0, 0.0 ];
-                            var topProbabilityLabelIndexes = [ 0, 0, 0 ];
-                            // SqueezeNet returns a list of 1000 options, with probabilities for each, loop through all
-                            for (var i = 0, len = resultVector.length; i < len; i++)
+                            var indexedResults = [];
+                            for (var i = 0; i < resultVector.length; i++)
                             {
-                                // is it one of the top 3?
-                                for (var j = 0; j < 3; j++)
-                                {
-                                    if (resultVector[i] > topProbabilities[j]) {
-                                        topProbabilityLabelIndexes[j] = i;
-                                        topProbabilities[j] = resultVector[i];
-                                        break;
-                                    }
-                                }
+                                indexedResults.push({index: i, probability: resultVector[i]});
                             }
+                            indexedResults.sort((a, b) => {
+                                if (a.probability < b.probability) return 1;
+                                else if (a.probability > b.probability) return -1;
+                                else return 0;
+                            });
                             // Display the result
                             var message = "";
                             for (var i = 0; i < 3; i++)
                             {
-                                message += "\n" + _labels[topProbabilityLabelIndexes[i]] + " with confidence of " + topProbabilities[i];
+                                message += "\n" + _labels[indexedResults[i].index] + " with confidence of " + indexedResults[i].probability;
                             }
                             // preview the image stream
                             document.getElementById("previewImage").src = URL.createObjectURL(file, { oneTimeOnly: true });


### PR DESCRIPTION
Fixes a bug in our samples that use Squeezenet where the top 3 probabilities that are extracted from the result vector can be inaccurate in many cases due to a bug in the sorting algorithm implemented. When I fixed the bug the output actually was different for the third most probable label when running with the kitten picture.