### PR TITLE
Change so Garbage Tensors don't use extra string stream to generate garbage data

### DIFF
--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -197,9 +197,18 @@ namespace BindingUtilities
             case TensorKind::Float:
             {
                 ModelBinding<float> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<float>(elementStrings, binding);
-                return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                if (csvFilePath.empty())
+                {
+                    float* data = binding.GetData();
+                    memset(data, 0, binding.GetDataBufferSize());
+                    return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                }
+                else
+                {
+                    auto elementStrings = ParseCSVElementStrings(csvFilePath);
+                    WriteDataToBinding<float>(elementStrings, binding);
+                    return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                }
             }
             break;
             case TensorKind::Float16:

--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -176,7 +176,7 @@ namespace BindingUtilities
     }
 
     // Binds tensor floats, ints, doubles from CSV data.
-    ITensor CreateBindableTensor(const ILearningModelFeatureDescriptor& description, const std::wstring& csvFilePath)
+    ITensor CreateBindableTensor(const ILearningModelFeatureDescriptor& description, const CommandLineArgs& args)
     {
         auto name = description.Name();
         auto tensorDescriptor = description.try_as<TensorFeatureDescriptor>();
@@ -187,6 +187,7 @@ namespace BindingUtilities
             throw;
         }
 
+        std::vector<std::string> elementStrings;
         switch (tensorDescriptor.TensorKind())
         {
             case TensorKind::Undefined:
@@ -197,97 +198,165 @@ namespace BindingUtilities
             case TensorKind::Float:
             {
                 ModelBinding<float> binding(description);
-                if (csvFilePath.empty())
+                if (args.IsGarbageInput())
                 {
-                    float* data = binding.GetData();
-                    memset(data, 0, binding.GetDataBufferSize());
-                    return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                    memset(binding.GetData(), 0, sizeof(float) * binding.GetDataBufferSize());
                 }
                 else
                 {
-                    auto elementStrings = ParseCSVElementStrings(csvFilePath);
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
                     WriteDataToBinding<float>(elementStrings, binding);
-                    return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
                 }
+                return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Float16:
             {
                 ModelBinding<float> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<float>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(float) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<float>(elementStrings, binding);
+                }
                 return TensorFloat16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Double:
             {
                 ModelBinding<double> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<double>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(double) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<double>(elementStrings, binding);
+                }
                 return TensorDouble::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Int8:
             {
                 ModelBinding<uint8_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<uint8_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(uint8_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<uint8_t>(elementStrings, binding);
+                }
                 return TensorInt8Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::UInt8:
             {
                 ModelBinding<uint8_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<uint8_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(uint8_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<uint8_t>(elementStrings, binding);
+                }
                 return TensorUInt8Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Int16:
             {
                 ModelBinding<int16_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<int16_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(int16_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<int16_t>(elementStrings, binding);
+                }
                 return TensorInt16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::UInt16:
             {
                 ModelBinding<uint16_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<uint16_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(uint16_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<uint16_t>(elementStrings, binding);
+                }
                 return TensorUInt16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Int32:
             {
                 ModelBinding<int32_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<int32_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(int32_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<int32_t>(elementStrings, binding);
+                }
                 return TensorInt32Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::UInt32:
             {
                 ModelBinding<uint32_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<uint32_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(uint32_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<uint32_t>(elementStrings, binding);
+                }
                 return TensorUInt32Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::Int64:
             {
                 ModelBinding<int64_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<int64_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(int64_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<int64_t>(elementStrings, binding);
+                }
                 return TensorInt64Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;
             case TensorKind::UInt64:
             {
                 ModelBinding<uint64_t> binding(description);
-                auto elementStrings = csvFilePath.empty() ? std::vector<std::string>(binding.GetDataBufferSize()) : ParseCSVElementStrings(csvFilePath);
-                WriteDataToBinding<uint64_t>(elementStrings, binding);
+                if (args.IsGarbageInput())
+                {
+                    memset(binding.GetData(), 0, sizeof(uint64_t) * binding.GetDataBufferSize());
+                }
+                else
+                {
+                    elementStrings = ParseCSVElementStrings(args.CsvPath());
+                    WriteDataToBinding<uint64_t>(elementStrings, binding);
+                }
                 return TensorUInt64Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
             }
             break;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -63,6 +63,12 @@ public:
         return m_createDeviceInWinML || !m_createDeviceOnClient;
     }
 
+    bool IsGarbageInput() const
+    {
+        // When there is no image or csv input provided, then garbage input binding is used.
+        return m_imagePath.empty() && m_csvData.empty();
+    }
+
     uint32_t NumIterations() const { return m_numIterations; }
 
 private:


### PR DESCRIPTION
Before this PR, WriteDataToBinding was still called even though the intent was to use garbage data. This change makes it so that arbitrary memory is created for the binding. The memory is memset to 0 so that garbage data results are deterministic and consistent.

**There is about a 2x performance increase with evaluate with this change since there is less time between GPU usage. Before this change, the GPU powers down / power up between iterations.**

I ran Squeezenet 300 iterations specifying GPU as device and compared the captured average performance.

Before this PR change:

  Load: 21.470000 ms
  Bind: 0.473307 ms
  **Evaluate: 18.5709 ms**
  Total Time: 40.5142 ms
  Working Set Memory usage (evaluate): 0 MB
  Dedicated Memory Usage (evaluate): 0 MB
  Shared Memory Usage (evaluate): 0 MB

After this PR change:

  Load: 46.911000 ms
  Bind: 0.685665 ms
  **Evaluate: 8.89519 ms**
  Total Time: 56.4919 ms
  Working Set Memory usage (evaluate): 0.00375366 MB
  Dedicated Memory Usage (evaluate): 0 MB
  Shared Memory Usage (evaluate): 0 MB
