### PR TITLE
Before creating session, print out learning model device. If gpu, print out gpu name

### DIFF
--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    void PrintLearningModelDevice(DeviceType deviceType, LearningModelDevice& device)
+    void PrintLearningModelDevice(DeviceType deviceType, const LearningModelDevice& device)
     {
         if (deviceType == DeviceType::CPU)
         {

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -144,7 +144,7 @@ public:
     {
         IDirect3DDevice d3dDevice = device.Direct3D11Device();
         com_ptr<IDirect3DDxgiInterfaceAccess> dxgi;
-        dxgi = d3dDevice.as<IDirect3DDxgiInterfaceAccess>();
+        dxgi = d3dDevice.try_as<IDirect3DDxgiInterfaceAccess>();
         if (dxgi)
         {
             com_ptr<IDXGIDevice> dxgiDevice;

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -7,9 +7,13 @@
 #include <utility>
 #include <codecvt>
 #include <iomanip>
+#include <dxgi.h>
+#include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 
 using namespace winrt::Windows::AI::MachineLearning;
 using namespace winrt::Windows::Storage::Streams;
+using namespace ::Windows::Graphics::DirectX::Direct3D11;
+using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
 // Stores performance information and handles output to the command line and CSV files.
 class OutputHelper
@@ -133,6 +137,29 @@ public:
                 std::wcout << L"GPU: " << description.Description << std::endl;
                 std::cout << std::endl;
             }
+        }
+    }
+
+    void PrintLearningModelDevice(LearningModelDevice& device)
+    {
+        IDirect3DDevice d3dDevice = device.Direct3D11Device();
+        com_ptr<IDirect3DDxgiInterfaceAccess> dxgi;
+        dxgi = d3dDevice.as<IDirect3DDxgiInterfaceAccess>();
+        if (dxgi)
+        {
+            com_ptr<IDXGIDevice> dxgiDevice;
+            dxgi->GetInterface(__uuidof(IDXGIDevice), dxgiDevice.put_void());
+            com_ptr<IDXGIAdapter> adapter;
+            dxgiDevice->GetAdapter(adapter.put());
+            DXGI_ADAPTER_DESC description;
+            if (SUCCEEDED(adapter->GetDesc(&description)))
+            {
+                std::wcout << L"\nCreating Session with GPU: " << description.Description << std::endl;
+            }
+        }
+        else
+        {
+            std::cout << "\nCreating Session with CPU device" << std::endl;
         }
     }
 

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -140,8 +140,14 @@ public:
         }
     }
 
-    void PrintLearningModelDevice(LearningModelDevice& device)
+    void PrintLearningModelDevice(DeviceType deviceType, LearningModelDevice& device)
     {
+        if (deviceType == DeviceType::CPU)
+        {
+            std::cout << "\nCreating Session with CPU device" << std::endl;
+            return;
+        }
+
         IDirect3DDevice d3dDevice = device.Direct3D11Device();
         com_ptr<IDirect3DDxgiInterfaceAccess> dxgi;
         dxgi = d3dDevice.try_as<IDirect3DDxgiInterfaceAccess>();
@@ -159,7 +165,7 @@ public:
         }
         else
         {
-            std::cout << "\nCreating Session with CPU device" << std::endl;
+            std::cout << "Failed to Print Learning Model Device Information" << std::endl;
         }
     }
 

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -242,13 +242,13 @@ HRESULT EvaluateModel(
 
             winrtDevice = inspectableDevice.as<IDirect3DDevice>();
             LearningModelDevice learningModelDevice = LearningModelDevice::CreateFromDirect3D11Device(winrtDevice);
-            output.PrintLearningModelDevice(learningModelDevice);
+            output.PrintLearningModelDevice(deviceType, learningModelDevice);
             session = LearningModelSession(model, learningModelDevice);
         }
         else
         {
             LearningModelDevice learningModelDevice(TypeHelper::GetWinmlDeviceKind(deviceType));
-            output.PrintLearningModelDevice(learningModelDevice);
+            output.PrintLearningModelDevice(deviceType, learningModelDevice);
             session = LearningModelSession(model, learningModelDevice);
         }
     }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -242,11 +242,14 @@ HRESULT EvaluateModel(
 
             winrtDevice = inspectableDevice.as<IDirect3DDevice>();
             LearningModelDevice learningModelDevice = LearningModelDevice::CreateFromDirect3D11Device(winrtDevice);
+            output.PrintLearningModelDevice(learningModelDevice);
             session = LearningModelSession(model, learningModelDevice);
         }
         else
         {
-            session = LearningModelSession(model, TypeHelper::GetWinmlDeviceKind(deviceType));
+            LearningModelDevice learningModelDevice(TypeHelper::GetWinmlDeviceKind(deviceType));
+            output.PrintLearningModelDevice(learningModelDevice);
+            session = LearningModelSession(model, learningModelDevice);
         }
     }
     catch (hresult_error hr)


### PR DESCRIPTION
This change accesses IDirect3DDevice from the LearningModelDevice and tries to print out the GPU name