### PR TITLE
Add setters to CommandlineArgs, Take Profiler as out parameter in Run

### DIFF
--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -73,7 +73,7 @@ namespace BindingUtilities
             BitmapDecoder decoder = BitmapDecoder::CreateAsync(stream).get();
 
             // If input dimensions are different from tensor input, then scale / crop while reading
-            if (args.AutoScale() &&
+            if (args.IsAutoScale() &&
                  ( decoder.PixelHeight() != height ||
                    decoder.PixelWidth() != width))
             {

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -33,9 +33,9 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -autoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
 }
 
-CommandLineArgs::CommandLineArgs(std::vector<std::wstring> & args)
+CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
 {
-    for (int i = 0; i < args.size(); i++)
+    for (UINT i = 0; i < args.size(); i++)
     {
         if ((_wcsicmp(args[i].c_str(), L"-CPU") == 0))
         {

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -33,113 +33,110 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -autoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
 }
 
-CommandLineArgs::CommandLineArgs()
+CommandLineArgs::CommandLineArgs(std::vector<std::wstring> & args)
 {
-    int numArgs = 0;
-    LPWSTR* args = CommandLineToArgvW(GetCommandLineW(), &numArgs);
-
-    for (int i = 0; i < numArgs; i++)
+    for (int i = 0; i < args.size(); i++)
     {
-        if ((_wcsicmp(args[i], L"-CPU") == 0))
+        if ((_wcsicmp(args[i].c_str(), L"-CPU") == 0))
         {
             m_useCPU = true;
         }
-        else if ((_wcsicmp(args[i], L"-GPU") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-GPU") == 0))
         {
             m_useGPU = true;
         }
-        else if ((_wcsicmp(args[i], L"-GPUHighPerformance") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-GPUHighPerformance") == 0))
         {
             m_useGPUHighPerformance = true;
         }
-        else if ((_wcsicmp(args[i], L"-GPUMinPower") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-GPUMinPower") == 0))
         {
             m_useGPUMinPower = true;
         }
-        else if ((_wcsicmp(args[i], L"-CreateDeviceOnClient") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-CreateDeviceOnClient") == 0))
         {
             m_createDeviceOnClient = true;
         }
-        else if ((_wcsicmp(args[i], L"-CreateDeviceInWinML") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-CreateDeviceInWinML") == 0))
         {
             m_createDeviceInWinML = true;
         }
-        else if ((_wcsicmp(args[i], L"-iterations") == 0) && (i + 1 < numArgs))
+        else if ((_wcsicmp(args[i].c_str(), L"-iterations") == 0) && (i + 1 < args.size()))
         {
-            m_numIterations = static_cast<UINT>(_wtoi(args[++i]));
+            m_numIterations = static_cast<UINT>(_wtoi(args[++i].c_str()));
         }
-        else if ((_wcsicmp(args[i], L"-model") == 0) && (i + 1 < numArgs))
+        else if ((_wcsicmp(args[i].c_str(), L"-model") == 0) && (i + 1 < args.size()))
         {
             m_modelPath = args[++i];
         }
-        else if ((_wcsicmp(args[i], L"-folder") == 0) && (i + 1 < numArgs))
+        else if ((_wcsicmp(args[i].c_str(), L"-folder") == 0) && (i + 1 < args.size()))
         {
             m_modelFolderPath = args[++i];
         }
-        else if ((_wcsicmp(args[i], L"-input") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-input") == 0))
         {
             m_inputData = args[++i];
         }
-        else if ((_wcsicmp(args[i], L"-output") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-output") == 0))
         {
             m_outputPath = args[++i];
         }
-        else if ((_wcsicmp(args[i], L"-RGB") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-RGB") == 0))
         {
             m_useRGB = true;
         }
-        else if ((_wcsicmp(args[i], L"-BGR") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-BGR") == 0))
         {
             m_useBGR = true;
         }
-        else if ((_wcsicmp(args[i], L"-tensor") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-tensor") == 0))
         {
             m_useTensor = true;
         }
-        else if ((_wcsicmp(args[i], L"-CPUBoundInput") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-CPUBoundInput") == 0))
         {
             m_useCPUBoundInput = true;
         }
-        else if ((_wcsicmp(args[i], L"-GPUBoundInput") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-GPUBoundInput") == 0))
         {
             m_useGPUBoundInput = true;
         }
-        else if ((_wcsicmp(args[i], L"-IgnoreFirstRun") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-IgnoreFirstRun") == 0))
         {
             m_ignoreFirstRun = true;
         }
-        else if ((_wcsicmp(args[i], L"-perf") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-perf") == 0))
         {
             m_perfCapture = true;
         }
-        else if ((_wcsicmp(args[i], L"-debug") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-debug") == 0))
         {
             m_debug = true;
         }
-        else if ((_wcsicmp(args[i], L"-savePerIterationPerf") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-savePerIterationPerf") == 0))
         {
             m_perIterCapture = true;
         }
-        else if ((_wcsicmp(args[i], L"-terse") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-terse") == 0))
         {
             m_terseOutput = true;
         }
-        else if ((_wcsicmp(args[i], L"-autoScale") == 0) && (i + 1 < numArgs))
+        else if ((_wcsicmp(args[i].c_str(), L"-autoScale") == 0) && (i + 1 < args.size()))
         {
             m_autoScale = true;
-            if (_wcsicmp(args[++i], L"Nearest") == 0)
+            if (_wcsicmp(args[++i].c_str(), L"Nearest") == 0)
             {
                 m_autoScaleInterpMode = BitmapInterpolationMode::NearestNeighbor;
             }
-            else if (_wcsicmp(args[i], L"Linear") == 0)
+            else if (_wcsicmp(args[i].c_str(), L"Linear") == 0)
             {
                 m_autoScaleInterpMode = BitmapInterpolationMode::Linear;
             }
-            else if (_wcsicmp(args[i], L"Cubic") == 0)
+            else if (_wcsicmp(args[i].c_str(), L"Cubic") == 0)
             {
                 m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
             }
-            else if (_wcsicmp(args[i], L"Fant") == 0)
+            else if (_wcsicmp(args[i].c_str(), L"Fant") == 0)
             {
                 m_autoScaleInterpMode = BitmapInterpolationMode::Fant;
             }
@@ -150,7 +147,7 @@ CommandLineArgs::CommandLineArgs()
                 return;
             }
         }
-        else if ((_wcsicmp(args[i], L"/?") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"/?") == 0))
         {
             PrintUsage();
             return;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -4,7 +4,7 @@
 class CommandLineArgs
 {
 public:
-    __declspec(dllexport) CommandLineArgs(std::vector<std::wstring> & args);
+    __declspec(dllexport) CommandLineArgs(std::vector<std::wstring>& args);
     void PrintUsage();
     bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
     bool IsUsingGPUMinPower() const { return m_useGPUMinPower; }

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -7,17 +7,18 @@ public:
     __declspec(dllexport) CommandLineArgs();
     void PrintUsage();
 
-    bool UseGPUHighPerformance() const { return m_useGPUHighPerformance; }
-    bool UseGPUMinPower() const { return m_useGPUMinPower; }
+    bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
+    bool IsUsingGPUMinPower() const { return m_useGPUMinPower; }
     bool UseBGR() const { return m_useBGR; }
-    bool UseGPUBoundInput() const { return m_useGPUBoundInput; }
-    bool IgnoreFirstRun() const { return m_ignoreFirstRun; }
-    bool PerfCapture() const { return m_perfCapture; }
-    bool EnableDebugOutput() const { return m_debug; }
+    bool IsUsingGPUBoundInput() const { return m_useGPUBoundInput; }
+    bool IsIgnoreFirstRun() const { return m_ignoreFirstRun; }
+    bool IsPerformanceCapture() const { return m_perfCapture; }
+    bool IsDebugOutputEnabled() const { return m_debug; }
     bool Silent() const { return m_silent; }
-    bool PerIterCapture() const { return m_perIterCapture; }
-    bool CreateDeviceOnClient() const { return m_createDeviceOnClient; }
-    bool AutoScale() const { return m_autoScale; }
+    bool IsPerIterationCapture() const { return m_perIterCapture; }
+    bool IsCreateDeviceOnClient() const { return m_createDeviceOnClient; }
+    bool IsAutoScale() const { return m_autoScale; }
+
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
    
     const std::wstring& ImagePath() const { return m_imagePath; }
@@ -25,8 +26,6 @@ public:
     const std::wstring& OutputPath() const { return m_outputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
-
-    void SetModelPath(std::wstring path) { m_modelPath = path; }
 
     bool UseRGB() const
     {
@@ -70,6 +69,27 @@ public:
     }
 
     uint32_t NumIterations() const { return m_numIterations; }
+
+    void ToggleCPU(const bool useCPU) { m_useCPU = useCPU; }
+    void ToggleGPU(const bool useGPU) { m_useGPU = useGPU; }
+    void ToggleGPUHighPerformance(const bool useGPUHighPerformance) { m_useGPUHighPerformance = useGPUHighPerformance; }
+    void ToggleUseGPUMinPower(const bool useGPUMinPower) { m_useGPUMinPower = useGPUMinPower; }
+    void ToggleCreateDeviceOnClient(const bool createDeviceOnClient) { m_createDeviceOnClient = createDeviceOnClient; }
+    void ToggleCreateDeviceInWinML(const bool createDeviceInWinML) { m_createDeviceInWinML = createDeviceInWinML; }
+    void ToggleCPUBoundInput(const bool useCPUBoundInput) { m_useCPUBoundInput = useCPUBoundInput; }
+    void ToggleGPUBoundInput(const bool useGPUBoundInput) { m_useGPUBoundInput = useGPUBoundInput; }
+    void ToggleUseRGB(const bool useRGBImage) {m_useRGB = useRGBImage;}
+    void ToggleUseBGR(const bool useBGRImage) {m_useBGR = useBGRImage;}
+    void ToggleUseTensor(const bool useTensor) { m_useTensor = useTensor; }
+    void TogglePerformanceCapture(const bool perfCapture) { m_perfCapture = perfCapture; }
+    void ToggleIgnoreFirstRun(const bool ignoreFirstRun) { m_ignoreFirstRun=ignoreFirstRun;}
+    void TogglePerIterationPerformanceCapture(const bool perIterCapture) { m_perIterCapture = perIterCapture; }
+    void ToggleDebugOutput(const bool debug) { m_debug = debug; }
+
+
+    void SetModelPath(const std::wstring modelPath) { m_modelPath = modelPath; }
+    void SetInputDataPath(const std::wstring inputDataPath) { m_inputData = inputDataPath; }
+    void SetPerformanceCSVPath(const std::wstring performanceCSVPath) { m_outputPath = performanceCSVPath; }
 
 private:
     bool m_perfCapture = false;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -4,9 +4,8 @@
 class CommandLineArgs
 {
 public:
-    __declspec(dllexport) CommandLineArgs();
+    __declspec(dllexport) CommandLineArgs(std::vector<std::wstring> & args);
     void PrintUsage();
-
     bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
     bool IsUsingGPUMinPower() const { return m_useGPUMinPower; }
     bool UseBGR() const { return m_useBGR; }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -27,7 +27,7 @@ LearningModel LoadModel(const std::wstring path, bool capturePerf, OutputHelper&
         if (capturePerf)
         {
             WINML_PROFILING_STOP(g_Profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
-            if (args.PerIterCapture())
+            if (args.IsPerIterationCapture())
             {
                 output.SaveLoadTimes(g_Profiler, iterationNum);
             }
@@ -118,7 +118,7 @@ HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding
         if (capturePerf)
         {
             WINML_PROFILING_STOP(g_Profiler, WINML_MODEL_TEST_PERF::BIND_VALUE);
-            if (args.PerIterCapture())
+            if (args.IsPerIterationCapture())
             {
                 output.SaveBindTimes(g_Profiler, iterationNum);
             }
@@ -163,7 +163,7 @@ HRESULT EvaluateModel(
         if (capturePerf)
         {
             WINML_PROFILING_STOP(g_Profiler, WINML_MODEL_TEST_PERF::EVAL_MODEL);
-            if (args.PerIterCapture())
+            if (args.IsPerIterationCapture())
             {
                 output.SaveEvalPerformance(g_Profiler, iterationNum);
             }
@@ -259,7 +259,7 @@ HRESULT EvaluateModel(
         return hr.code();
     }
 
-    if (args.EnableDebugOutput())
+    if (args.IsDebugOutputEnabled())
     {
         // Enables trace log output. 
         session.EvaluationProperties().Insert(L"EnableDebugOutput", nullptr);
@@ -270,12 +270,12 @@ HRESULT EvaluateModel(
     bool useInputData = false;
     
     // Add one more iteration if we ignore the first run
-    uint32_t numIterations = args.NumIterations() + args.IgnoreFirstRun();
+    uint32_t numIterations = args.NumIterations() + args.IsIgnoreFirstRun();
 
     // Run the binding + evaluate multiple times and average the results
     for (uint32_t i = 0; i < numIterations; i++)
     {
-        bool captureIterationPerf = (args.PerfCapture() && (!args.IgnoreFirstRun() || i > 0)) || (args.PerIterCapture());
+        bool captureIterationPerf = (args.IsPerformanceCapture() && (!args.IsIgnoreFirstRun() || i > 0)) || (args.IsPerIterationCapture());
 
         output.PrintBindingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation);
 
@@ -331,7 +331,7 @@ HRESULT EvaluateModels(
 
         try
         {
-            model = LoadModel(path, args.PerfCapture() || args.PerIterCapture(), output, args, 0);
+            model = LoadModel(path, args.IsPerformanceCapture() || args.IsPerIterationCapture(), output, args, 0);
         }
         catch (hresult_error hr)
         {
@@ -357,7 +357,7 @@ HRESULT EvaluateModels(
                 {
                     for (auto deviceCreationLocation : deviceCreationLocations)
                     {
-                        if (args.PerfCapture() || args.PerIterCapture())
+                        if (args.IsPerformanceCapture() || args.IsPerIterationCapture())
                         {
                             // Resets all values from profiler for bind and evaluate.
                             g_Profiler.Reset(WINML_MODEL_TEST_PERF::BIND_VALUE, WINML_MODEL_TEST_PERF::COUNT);
@@ -379,7 +379,7 @@ HRESULT EvaluateModels(
                             return evalHResult;
                         }
 
-                        if (args.PerfCapture())
+                        if (args.IsPerformanceCapture())
                         {
                             output.PrintResults(g_Profiler, args.NumIterations(), deviceType, inputBindingType, inputDataType, deviceCreationLocation);
                             output.WritePerformanceDataToCSV(
@@ -390,11 +390,11 @@ HRESULT EvaluateModels(
                                 TypeHelper::Stringify(inputDataType),
                                 TypeHelper::Stringify(inputBindingType),
                                 TypeHelper::Stringify(deviceCreationLocation),
-                                args.IgnoreFirstRun()
+                                args.IsIgnoreFirstRun()
                             );
                         }
 
-                        if (args.PerIterCapture())
+                        if (args.IsPerIterationCapture())
                         {
                             output.WritePerformanceDataToCSVPerIteration(g_Profiler, args, args.ModelPath(), args.ImagePath());
                         }
@@ -445,12 +445,12 @@ std::vector<DeviceType> FetchDeviceTypes(const CommandLineArgs& args)
         deviceTypes.push_back(DeviceType::DefaultGPU);
     }
 
-    if (args.UseGPUHighPerformance())
+    if (args.IsUsingGPUHighPerformance())
     {
         deviceTypes.push_back(DeviceType::HighPerfGPU);
     }
 
-    if (args.UseGPUMinPower())
+    if (args.IsUsingGPUMinPower())
     {
         deviceTypes.push_back(DeviceType::MinPowerGPU);
     }
@@ -467,7 +467,7 @@ std::vector<InputBindingType> FetchInputBindingTypes(const CommandLineArgs& args
         inputBindingTypes.push_back(InputBindingType::CPU);
     }
 
-    if (args.UseGPUBoundInput())
+    if (args.IsUsingGPUBoundInput())
     {
         inputBindingTypes.push_back(InputBindingType::GPU);
     }
@@ -484,7 +484,7 @@ std::vector<DeviceCreationLocation> FetchDeviceCreationLocations(const CommandLi
         deviceCreationLocations.push_back(DeviceCreationLocation::WinML);
     }
 
-    if (args.CreateDeviceOnClient())
+    if (args.IsCreateDeviceOnClient())
     {
         deviceCreationLocations.push_back(DeviceCreationLocation::ClientCode);
     }
@@ -511,7 +511,7 @@ int run(CommandLineArgs& args)
         output.SetDefaultCSVFileName();
     }
 
-    if (args.PerIterCapture()) {
+    if (args.IsPerIterationCapture()) {
         output.SetDefaultCSVFileNamePerIteration();
     }
 

--- a/Tools/WinMLRunner/src/Run.h
+++ b/Tools/WinMLRunner/src/Run.h
@@ -1,3 +1,3 @@
 #include "CommandLineArgs.h"
 
-__declspec(dllexport) int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& g_Profiler);
+__declspec(dllexport) int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler);

--- a/Tools/WinMLRunner/src/Run.h
+++ b/Tools/WinMLRunner/src/Run.h
@@ -1,3 +1,3 @@
 #include "CommandLineArgs.h"
 
-__declspec(dllexport) int run(CommandLineArgs& args);
+__declspec(dllexport) int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& g_Profiler);

--- a/Tools/WinMLRunner/src/TimerHelper.h
+++ b/Tools/WinMLRunner/src/TimerHelper.h
@@ -416,8 +416,11 @@ const static std::vector<std::wstring> CounterTypeName =
 class PerfCounterStatistics
 {
 public:
-    PerfCounterStatistics() : m_bDisabled(true)
+    PerfCounterStatistics()
     {
+        m_bDisabled = false;
+        Reset();
+        m_bDisabled = true;
     }
 
     void Enable()

--- a/Tools/WinMLRunner/src/main.cpp
+++ b/Tools/WinMLRunner/src/main.cpp
@@ -15,8 +15,6 @@ int main(int argc, char *argv[])
         argsList.push_back(converter.from_bytes(argv[i]));
     }
     CommandLineArgs commandLineArgs(argsList);
-    commandLineArgs.TogglePerformanceCapture(true);
-    Profiler<WINML_MODEL_TEST_PERF> g_Profiler;
-
-    return run(commandLineArgs, g_Profiler);;
+    Profiler<WINML_MODEL_TEST_PERF> profiler;
+    return run(commandLineArgs, profiler);;
 }

--- a/Tools/WinMLRunner/src/main.cpp
+++ b/Tools/WinMLRunner/src/main.cpp
@@ -1,8 +1,22 @@
 #include "CommandLineArgs.h"
 #include "Run.h"
+#include "Common.h"
+#include <iostream>
+#include <codecvt>
+using namespace std;
 
-int main()
+int main(int argc, char *argv[])
 {
-    CommandLineArgs args;
-    return run(args);
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+    vector<wstring> argsList;
+    for (int i = 0; i < argc; i++)
+    {
+        string str(argv[i]);
+        argsList.push_back(converter.from_bytes(argv[i]));
+    }
+    CommandLineArgs commandLineArgs(argsList);
+    commandLineArgs.TogglePerformanceCapture(true);
+    Profiler<WINML_MODEL_TEST_PERF> g_Profiler;
+
+    return run(commandLineArgs, g_Profiler);;
 }


### PR DESCRIPTION
This PR has a few changes:

- CommandLineArgs constructor takes in a vector of wstrings. Main.cpp in WinMLRunner constructs CommandLineArgs through access of Argv

- "Setter" methods were added to CommandlineArgs. The "getter" methods were renamed as well to be more intuitive. Please comment if the names could be improved.

- Run method takes in a Profiler by reference to populate as an out parameter.