### PR TITLE
Stop automatically outputting performance file for -perf flag

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -504,6 +504,8 @@ namespace WinMLRunnerTest
             const std::wstring command = BuildCommand({ EXE_PATH });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
         }
+        
+        /* Commenting out test until WinMLRunnerDLL.dll is properly written and ABI friendly
         TEST_METHOD(TestWinMLRunnerDllLinking)
         {
             // Before running rest of test, make sure that this file doesn't exist or 
@@ -523,5 +525,6 @@ namespace WinMLRunnerTest
             //rename back to original naming
             rename("WinMLRunnerDLL_renamed", "WinMLRunnerDLL.dll");
         }
+        */
     };
 }

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -106,7 +106,7 @@ namespace WinMLRunnerTest
 		TEST_METHOD(GarbageInputCpuAndGpu)
 		{
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -116,7 +116,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputOnlyCpu)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -126,7 +126,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputOnlyGpu)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -136,7 +136,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -146,7 +146,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -156,7 +156,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -166,7 +166,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -176,7 +176,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -186,7 +186,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -196,7 +196,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -206,7 +206,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -216,7 +216,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -226,7 +226,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -236,7 +236,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -246,7 +246,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -256,7 +256,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -266,7 +266,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -276,7 +276,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -286,7 +286,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -296,7 +296,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -306,7 +306,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -316,7 +316,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -326,7 +326,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundRGBImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -336,7 +336,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -346,7 +346,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundBGRImage)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -356,7 +356,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -366,7 +366,7 @@ namespace WinMLRunnerTest
         TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundTensor)
         {
             const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-output", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -380,7 +380,7 @@ namespace WinMLRunnerTest
                 EXE_PATH,
                 L"-model",
                 modelPath,
-                L"-output",
+                L"-PerfOutput",
                 OUTPUT_PATH,
                 L"-perf",
                 L"-CPU",
@@ -401,7 +401,7 @@ namespace WinMLRunnerTest
 
         TEST_METHOD(RunAllModelsInFolderGarbageInput)
         {
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-output", OUTPUT_PATH, L"-perf" });
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
             Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
 
             // We need to expect one more line because of the header
@@ -414,7 +414,7 @@ namespace WinMLRunnerTest
                 EXE_PATH,
                 L"-folder",
                 INPUT_FOLDER_PATH,
-                L"-output",
+                L"-PerfOutput",
                 OUTPUT_PATH,
                 L"-perf",
                 L"-CPU",

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -22,8 +22,8 @@ Required command-Line arguments:
 -folder <path>           : Fully qualifed path to a folder with .onnx and/or .pb models, will run all of the models in the folder.
 
 #Optional command-line arguments:
--perf                    : Captures GPU, CPU, and wall-clock time measurements. 
--iterations <int>        : Number of times to evaluate the model when capturing performance measurements.
+-Perf                    : Captures GPU, CPU, and wall-clock time measurements.
+-Iterations <int>        : Number of times to evaluate the model when capturing performance measurements.
 -CPU                     : Will create a session on the CPU.
 -GPU                     : Will create a session on the GPU.
 -GPUHighPerformance      : Will create a session with the most powerful GPU device available.
@@ -34,14 +34,14 @@ Required command-Line arguments:
 -GPUBoundInput           : Will bind the input to the GPU.
 -BGR                     : Will load the input as a BGR image.
 -RGB                     : Will load the input as an RGB image.
--tensor                  : Will load the input as a tensor.
--input <image/CSV path>  : Will bind image/data from CSV to model.
--output <CSV path>       : Path to the CSV where the perf results will be written.
+-Tensor                  : Will load the input as a tensor.
+-Input <image/CSV path>  : Will bind image/data from CSV to model.
+-PerfOutput <CSV path>   : Path to the CSV where the perf results will be written.
 -IgnoreFirstRun          : Will ignore the first run in the perf results when calculating the average
--savePerIterationPerf	 : Save per iteration performance results to csv file.
--debug                   : Will start a trace logging session.
--terse                   : Will suppress repetitive console output (initial iteration and summary info will be output).
--autoScale <mode>        : Will automatically scale an input image to match the required input dimensions of the model.  Pass in the interpolation mode, one of ["Nearest", "Linear", "Cubic", "Fant"].
+-SavePerIterationPerf	 : Save per iteration performance results to csv file.
+-Debug                   : Will start a trace logging session.
+-Terse                   : Will suppress repetitive console output (initial iteration and summary info will be output).
+-AutoScale <mode>        : Will automatically scale an input image to match the required input dimensions of the model.  Pass in the interpolation mode, one of ["Nearest", "Linear", "Cubic", "Fant"].
 
  ```
 

--- a/Tools/WinMLRunner/WinMLRunner.sln
+++ b/Tools/WinMLRunner/WinMLRunner.sln
@@ -3,20 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinMLRunnerDLL", "WinMLRunnerDLL.vcxproj", "{81EA9CC6-8A26-4583-B1A4-84740EF815C8}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinMLRunnerTest", "..\..\Testing\WinMLRunnerTest\WinMLRunnerTest.vcxproj", "{E9D4AC92-8295-4FB4-BF7D-3FAF74B564E8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{31653A2F-02CC-4A95-9880-BF86965FB262} = {31653A2F-02CC-4A95-9880-BF86965FB262}
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2} = {A1DFBB85-290F-4D1C-8699-0100DB6373F2}
 		{C3BCBEA1-90E6-426F-88AC-64C274BCEF45} = {C3BCBEA1-90E6-426F-88AC-64C274BCEF45}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinMLRunner", "WinMLRunner.vcxproj", "{31653A2F-02CC-4A95-9880-BF86965FB262}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinMLRunnerStaticLib", "WinMLRunnerStaticLib.vcxproj", "{C3BCBEA1-90E6-426F-88AC-64C274BCEF45}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinMLRunner_Link_DLL", "WinMLRunner_Link_DLL.vcxproj", "{A1DFBB85-290F-4D1C-8699-0100DB6373F2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,18 +23,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|ARM64.Build.0 = Debug|ARM64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|x64.ActiveCfg = Debug|x64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|x64.Build.0 = Debug|x64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|x86.ActiveCfg = Debug|Win32
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Debug|x86.Build.0 = Debug|Win32
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|ARM64.ActiveCfg = Release|ARM64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|ARM64.Build.0 = Release|ARM64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|x64.ActiveCfg = Release|x64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|x64.Build.0 = Release|x64
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|x86.ActiveCfg = Release|Win32
-		{81EA9CC6-8A26-4583-B1A4-84740EF815C8}.Release|x86.Build.0 = Release|Win32
 		{E9D4AC92-8295-4FB4-BF7D-3FAF74B564E8}.Debug|ARM64.ActiveCfg = Debug|Win32
 		{E9D4AC92-8295-4FB4-BF7D-3FAF74B564E8}.Debug|x64.ActiveCfg = Debug|x64
 		{E9D4AC92-8295-4FB4-BF7D-3FAF74B564E8}.Debug|x64.Build.0 = Debug|x64
@@ -74,18 +57,6 @@ Global
 		{C3BCBEA1-90E6-426F-88AC-64C274BCEF45}.Release|x64.Build.0 = Release|x64
 		{C3BCBEA1-90E6-426F-88AC-64C274BCEF45}.Release|x86.ActiveCfg = Release|Win32
 		{C3BCBEA1-90E6-426F-88AC-64C274BCEF45}.Release|x86.Build.0 = Release|Win32
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|ARM64.Build.0 = Debug|ARM64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|x64.ActiveCfg = Debug|x64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|x64.Build.0 = Debug|x64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|x86.ActiveCfg = Debug|Win32
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Debug|x86.Build.0 = Debug|Win32
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|ARM64.ActiveCfg = Release|ARM64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|ARM64.Build.0 = Release|ARM64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|x64.ActiveCfg = Release|x64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|x64.Build.0 = Release|x64
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|x86.ActiveCfg = Release|Win32
-		{A1DFBB85-290F-4D1C-8699-0100DB6373F2}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -25,7 +25,7 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -perf : capture timing measurements" << std::endl;
     std::cout << "  -iterations : # times perf measurements will be run/averaged" << std::endl;
     std::cout << "  -input <fully qualified path>: binds image or CSV to model" << std::endl;
-    std::cout << "  -output <fully qualified path>: csv file to write the perf results to" << std::endl;
+    std::cout << "  -perfOutput optional:<fully qualified path>: csv file to write the perf results to" << std::endl;
     std::cout << "  -IgnoreFirstRun : ignore the first run in the perf results when calculating the average" << std::endl;
     std::cout << "  -savePerIterationPerf : save per iteration performance results to csv file" << std::endl;
     std::cout << "  -debug: print trace logs" << std::endl;
@@ -77,9 +77,13 @@ CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
         {
             m_inputData = args[++i];
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-output") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-perfOutput") == 0))
         {
-            m_outputPath = args[++i];
+            if (i + 1 < args.size() && args[++i][0] != *L"-")
+            {
+                m_outputPath = args[++i];
+            }
+            m_perfOutput = true;
         }
         else if ((_wcsicmp(args[i].c_str(), L"-RGB") == 0))
         {

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -21,19 +21,19 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -GPUBoundInput : bind the input to the GPU" << std::endl;
     std::cout << "  -RGB : load the input as an RGB image" << std::endl;
     std::cout << "  -BGR : load the input as a BGR image" << std::endl;
-    std::cout << "  -tensor : load the input as a tensor" << std::endl;
-    std::cout << "  -perf : capture timing measurements" << std::endl;
-    std::cout << "  -iterations : # times perf measurements will be run/averaged" << std::endl;
-    std::cout << "  -input <fully qualified path>: binds image or CSV to model" << std::endl;
-    std::cout << "  -perfOutput optional:<fully qualified path>: csv file to write the perf results to" << std::endl;
+    std::cout << "  -Tensor : load the input as a tensor" << std::endl;
+    std::cout << "  -Perf : capture timing measurements" << std::endl;
+    std::cout << "  -Iterations : # times perf measurements will be run/averaged" << std::endl;
+    std::cout << "  -Input <fully qualified path>: binds image or CSV to model" << std::endl;
+    std::cout << "  -PerfOutput optional:<fully qualified path>: csv file to write the perf results to" << std::endl;
     std::cout << "  -IgnoreFirstRun : ignore the first run in the perf results when calculating the average" << std::endl;
-    std::cout << "  -savePerIterationPerf : save per iteration performance results to csv file" << std::endl;
-    std::cout << "  -debug: print trace logs" << std::endl;
-    std::cout << "  -terse: Terse Mode (suppresses repetitive console output)" << std::endl;
-    std::cout << "  -autoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
+    std::cout << "  -SavePerIterationPerf : save per iteration performance results to csv file" << std::endl;
+    std::cout << "  -Debug: print trace logs" << std::endl;
+    std::cout << "  -Terse: Terse Mode (suppresses repetitive console output)" << std::endl;
+    std::cout << "  -AutoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
 }
 
-CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
+CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
 {
     for (UINT i = 0; i < args.size(); i++)
     {
@@ -61,27 +61,27 @@ CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
         {
             m_createDeviceInWinML = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-iterations") == 0) && (i + 1 < args.size()))
+        else if ((_wcsicmp(args[i].c_str(), L"-Iterations") == 0) && (i + 1 < args.size()))
         {
             m_numIterations = static_cast<UINT>(_wtoi(args[++i].c_str()));
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-model") == 0) && (i + 1 < args.size()))
+        else if ((_wcsicmp(args[i].c_str(), L"-Model") == 0) && (i + 1 < args.size()))
         {
             m_modelPath = args[++i];
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-folder") == 0) && (i + 1 < args.size()))
+        else if ((_wcsicmp(args[i].c_str(), L"-Folder") == 0) && (i + 1 < args.size()))
         {
             m_modelFolderPath = args[++i];
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-input") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-Input") == 0))
         {
             m_inputData = args[++i];
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-perfOutput") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-PerfOutput") == 0))
         {
-            if (i + 1 < args.size() && args[++i][0] != *L"-")
+            if (i + 1 < args.size() && args[i+1][0] != L'-')
             {
-                m_outputPath = args[i];
+                m_perfOutputPath = args[++i];
             }
             m_perfOutput = true;
         }
@@ -93,7 +93,7 @@ CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
         {
             m_useBGR = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-tensor") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-Tensor") == 0))
         {
             m_useTensor = true;
         }
@@ -109,23 +109,23 @@ CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
         {
             m_ignoreFirstRun = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-perf") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-Perf") == 0))
         {
             m_perfCapture = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-debug") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-Debug") == 0))
         {
             m_debug = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-savePerIterationPerf") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-SavePerIterationPerf") == 0))
         {
             m_perIterCapture = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-terse") == 0))
+        else if ((_wcsicmp(args[i].c_str(), L"-Terse") == 0))
         {
             m_terseOutput = true;
         }
-        else if ((_wcsicmp(args[i].c_str(), L"-autoScale") == 0) && (i + 1 < args.size()))
+        else if ((_wcsicmp(args[i].c_str(), L"-AutoScale") == 0) && (i + 1 < args.size()))
         {
             m_autoScale = true;
             if (_wcsicmp(args[++i].c_str(), L"Nearest") == 0)

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -81,7 +81,7 @@ CommandLineArgs::CommandLineArgs(std::vector<std::wstring>& args)
         {
             if (i + 1 < args.size() && args[++i][0] != *L"-")
             {
-                m_outputPath = args[++i];
+                m_outputPath = args[i];
             }
             m_perfOutput = true;
         }

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -4,6 +4,7 @@
 class CommandLineArgs
 {
 public:
+    CommandLineArgs() {};
     __declspec(dllexport) CommandLineArgs(std::vector<std::wstring>& args);
     void PrintUsage();
     bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
@@ -17,6 +18,8 @@ public:
     bool IsPerIterationCapture() const { return m_perIterCapture; }
     bool IsCreateDeviceOnClient() const { return m_createDeviceOnClient; }
     bool IsAutoScale() const { return m_autoScale; }
+    bool IsOutputPerf() const { return m_perfOutput; }
+
 
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
    
@@ -84,12 +87,17 @@ public:
     void ToggleIgnoreFirstRun(const bool ignoreFirstRun) { m_ignoreFirstRun=ignoreFirstRun;}
     void TogglePerIterationPerformanceCapture(const bool perIterCapture) { m_perIterCapture = perIterCapture; }
     void ToggleDebugOutput(const bool debug) { m_debug = debug; }
+    void ToggleTerseOutput(const bool terseOutput) { m_terseOutput = terseOutput; }
 
 
     void SetModelPath(const std::wstring modelPath) { m_modelPath = modelPath; }
     void SetInputDataPath(const std::wstring inputDataPath) { m_inputData = inputDataPath; }
-    void SetPerformanceCSVPath(const std::wstring performanceCSVPath) { m_outputPath = performanceCSVPath; }
-
+    void SetPerformanceCSVPath(const std::wstring performanceCSVPath)
+    {
+        m_outputPath = performanceCSVPath;
+        m_perfOutput = true;
+    }
+    void SetRunIterations(const uint32_t iterations) { m_numIterations = iterations; }
 private:
     bool m_perfCapture = false;
     bool m_useCPU = false;
@@ -108,6 +116,7 @@ private:
     bool m_perIterCapture = false;
     bool m_terseOutput = false;
     bool m_autoScale = false;
+    bool m_perfOutput = false;
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
 
     std::wstring m_modelFolderPath;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -5,7 +5,7 @@ class CommandLineArgs
 {
 public:
     CommandLineArgs() {};
-    __declspec(dllexport) CommandLineArgs(std::vector<std::wstring>& args);
+    CommandLineArgs(const std::vector<std::wstring>& args);
     void PrintUsage();
     bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
     bool IsUsingGPUMinPower() const { return m_useGPUMinPower; }
@@ -25,7 +25,7 @@ public:
    
     const std::wstring& ImagePath() const { return m_imagePath; }
     const std::wstring& CsvPath() const { return m_csvData; }
-    const std::wstring& OutputPath() const { return m_outputPath; }
+    const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
 
@@ -90,11 +90,11 @@ public:
     void ToggleTerseOutput(const bool terseOutput) { m_terseOutput = terseOutput; }
 
 
-    void SetModelPath(const std::wstring modelPath) { m_modelPath = modelPath; }
-    void SetInputDataPath(const std::wstring inputDataPath) { m_inputData = inputDataPath; }
-    void SetPerformanceCSVPath(const std::wstring performanceCSVPath)
+    void SetModelPath(const std::wstring& modelPath) { m_modelPath = modelPath; }
+    void SetInputDataPath(const std::wstring& inputDataPath) { m_inputData = inputDataPath; }
+    void SetPerformanceCSVPath(const std::wstring& performanceCSVPath)
     {
-        m_outputPath = performanceCSVPath;
+        m_perfOutputPath = performanceCSVPath;
         m_perfOutput = true;
     }
     void SetRunIterations(const uint32_t iterations) { m_numIterations = iterations; }
@@ -124,6 +124,6 @@ private:
     std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
-    std::wstring m_outputPath;
+    std::wstring m_perfOutputPath;
     uint32_t m_numIterations = 1;
 };

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -72,22 +72,22 @@ public:
 
     uint32_t NumIterations() const { return m_numIterations; }
 
-    void ToggleCPU(const bool useCPU) { m_useCPU = useCPU; }
-    void ToggleGPU(const bool useGPU) { m_useGPU = useGPU; }
-    void ToggleGPUHighPerformance(const bool useGPUHighPerformance) { m_useGPUHighPerformance = useGPUHighPerformance; }
-    void ToggleUseGPUMinPower(const bool useGPUMinPower) { m_useGPUMinPower = useGPUMinPower; }
-    void ToggleCreateDeviceOnClient(const bool createDeviceOnClient) { m_createDeviceOnClient = createDeviceOnClient; }
-    void ToggleCreateDeviceInWinML(const bool createDeviceInWinML) { m_createDeviceInWinML = createDeviceInWinML; }
-    void ToggleCPUBoundInput(const bool useCPUBoundInput) { m_useCPUBoundInput = useCPUBoundInput; }
-    void ToggleGPUBoundInput(const bool useGPUBoundInput) { m_useGPUBoundInput = useGPUBoundInput; }
-    void ToggleUseRGB(const bool useRGBImage) {m_useRGB = useRGBImage;}
-    void ToggleUseBGR(const bool useBGRImage) {m_useBGR = useBGRImage;}
-    void ToggleUseTensor(const bool useTensor) { m_useTensor = useTensor; }
-    void TogglePerformanceCapture(const bool perfCapture) { m_perfCapture = perfCapture; }
-    void ToggleIgnoreFirstRun(const bool ignoreFirstRun) { m_ignoreFirstRun=ignoreFirstRun;}
-    void TogglePerIterationPerformanceCapture(const bool perIterCapture) { m_perIterCapture = perIterCapture; }
-    void ToggleDebugOutput(const bool debug) { m_debug = debug; }
-    void ToggleTerseOutput(const bool terseOutput) { m_terseOutput = terseOutput; }
+    void ToggleCPU(bool useCPU) { m_useCPU = useCPU; }
+    void ToggleGPU(bool useGPU) { m_useGPU = useGPU; }
+    void ToggleGPUHighPerformance(bool useGPUHighPerformance) { m_useGPUHighPerformance = useGPUHighPerformance; }
+    void ToggleUseGPUMinPower(bool useGPUMinPower) { m_useGPUMinPower = useGPUMinPower; }
+    void ToggleCreateDeviceOnClient(bool createDeviceOnClient) { m_createDeviceOnClient = createDeviceOnClient; }
+    void ToggleCreateDeviceInWinML(bool createDeviceInWinML) { m_createDeviceInWinML = createDeviceInWinML; }
+    void ToggleCPUBoundInput(bool useCPUBoundInput) { m_useCPUBoundInput = useCPUBoundInput; }
+    void ToggleGPUBoundInput(bool useGPUBoundInput) { m_useGPUBoundInput = useGPUBoundInput; }
+    void ToggleUseRGB(bool useRGBImage) {m_useRGB = useRGBImage;}
+    void ToggleUseBGR(bool useBGRImage) {m_useBGR = useBGRImage;}
+    void ToggleUseTensor(bool useTensor) { m_useTensor = useTensor; }
+    void TogglePerformanceCapture(bool perfCapture) { m_perfCapture = perfCapture; }
+    void ToggleIgnoreFirstRun(bool ignoreFirstRun) { m_ignoreFirstRun=ignoreFirstRun;}
+    void TogglePerIterationPerformanceCapture(bool perIterCapture) { m_perIterCapture = perIterCapture; }
+    void ToggleDebugOutput(bool debug) { m_debug = debug; }
+    void ToggleTerseOutput(bool terseOutput) { m_terseOutput = terseOutput; }
 
 
     void SetModelPath(const std::wstring& modelPath) { m_modelPath = modelPath; }

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -1,6 +1,7 @@
 #pragma once
-
+#ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+#endif
 // unknown.h needs to be inlcuded before any winrt headers
 #include <unknwn.h>
 #include <winrt/Windows.AI.MachineLearning.h>

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -377,7 +377,7 @@ public:
             if (bNewFile)
             {
                 fout << "Model Name" << ","
-                     << "Model Binding" << ","
+                     << "Device Type" << ","
                      << "Input Binding" << ","
                      << "Input Type" << ","
                      << "Device Creation Location" << ","

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -340,7 +340,7 @@ public:
     void WritePerformanceDataToCSV(
         const Profiler<WINML_MODEL_TEST_PERF> &profiler,
         int numIterations, std::wstring model,
-        std::string modelBinding,
+        std::string deviceType,
         std::string inputBinding,
         std::string inputType,
         std::string deviceCreationLocation,
@@ -393,7 +393,7 @@ public:
             }
 
             fout << modelName << ","
-                 << modelBinding << ","
+                 << deviceType << ","
                  << inputBinding << ","
                  << inputType << ","
                  << deviceCreationLocation << ","

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -340,10 +340,10 @@ public:
     void WritePerformanceDataToCSV(
         const Profiler<WINML_MODEL_TEST_PERF> &profiler,
         int numIterations, std::wstring model,
-        std::string deviceType,
-        std::string inputBinding,
-        std::string inputType,
-        std::string deviceCreationLocation,
+        std::string& deviceType,
+        std::string& inputBinding,
+        std::string& inputType,
+        std::string& deviceCreationLocation,
         bool firstRunIgnored
     ) const
     {

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -197,7 +197,7 @@ HRESULT EvaluateModel(
     try
     {
         if (deviceCreationLocation == DeviceCreationLocation::ClientCode
-            && (deviceType != DeviceType::CPU))
+            && deviceType != DeviceType::CPU)
         {
             // Creating the device on the client and using it to create the video frame and initialize the session makes sure that everything is on
             // the same device. This usually avoids an expensive cross-device and cross-videoframe copy via the VideoFrame pipeline.

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -196,7 +196,8 @@ HRESULT EvaluateModel(
 
     try
     {
-        if (deviceCreationLocation == DeviceCreationLocation::ClientCode)
+        if (deviceCreationLocation == DeviceCreationLocation::ClientCode
+            && (deviceType != DeviceType::CPU))
         {
             // Creating the device on the client and using it to create the video frame and initialize the session makes sure that everything is on
             // the same device. This usually avoids an expensive cross-device and cross-videoframe copy via the VideoFrame pipeline.
@@ -392,16 +393,19 @@ HRESULT EvaluateModels(
                         if (args.IsPerformanceCapture())
                         {
                             output.PrintResults(profiler, args.NumIterations(), deviceType, inputBindingType, inputDataType, deviceCreationLocation);
-                            output.WritePerformanceDataToCSV(
-                                profiler,
-                                args.NumIterations(),
-                                path,
-                                TypeHelper::Stringify(deviceType),
-                                TypeHelper::Stringify(inputDataType),
-                                TypeHelper::Stringify(inputBindingType),
-                                TypeHelper::Stringify(deviceCreationLocation),
-                                args.IsIgnoreFirstRun()
-                            );
+                            if (args.IsOutputPerf())
+                            {
+                                output.WritePerformanceDataToCSV(
+                                    profiler,
+                                    args.NumIterations(),
+                                    path,
+                                    TypeHelper::Stringify(deviceType),
+                                    TypeHelper::Stringify(inputDataType),
+                                    TypeHelper::Stringify(inputBindingType),
+                                    TypeHelper::Stringify(deviceCreationLocation),
+                                    args.IsIgnoreFirstRun()
+                                );
+                            }
                         }
 
                         if (args.IsPerIterationCapture())

--- a/Tools/WinMLRunner/src/Run.h
+++ b/Tools/WinMLRunner/src/Run.h
@@ -1,3 +1,3 @@
 #include "CommandLineArgs.h"
 
-__declspec(dllexport) int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler);
+int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler);


### PR DESCRIPTION
-Perf flag would output performance numbers AND automatically create a CSV file. This change separates this so that -perfOutput flag <with optional csv file name> needs to be specified in order for the CSV file to be generated.

More changes contained in the PR:

- If _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS flag was already defined, then don't redefine it.
- "Model Binding" column in the perf csv file should actually be "Device Type"
- For creating d3d device on client and passing into session, this should only be supported if the DeviceType isn't CPU.