### PR TITLE
Fix build error WinMLRunner WritePerformanceDataToCSV

### DIFF
--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -340,10 +340,10 @@ public:
     void WritePerformanceDataToCSV(
         const Profiler<WINML_MODEL_TEST_PERF> &profiler,
         int numIterations, std::wstring model,
-        std::string& deviceType,
-        std::string& inputBinding,
-        std::string& inputType,
-        std::string& deviceCreationLocation,
+        const std::string& deviceType,
+        const std::string& inputBinding,
+        const std::string& inputType,
+        const std::string& deviceCreationLocation,
         bool firstRunIgnored
     ) const
     {

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -395,14 +395,18 @@ HRESULT EvaluateModels(
                             output.PrintResults(profiler, args.NumIterations(), deviceType, inputBindingType, inputDataType, deviceCreationLocation);
                             if (args.IsOutputPerf())
                             {
+                                std::string deviceTypeStringified = TypeHelper::Stringify(deviceType);
+                                std::string inputDataTypeStringified = TypeHelper::Stringify(inputDataType);
+                                std::string inputBindingTypeStringified = TypeHelper::Stringify(inputBindingType);
+                                std::string deviceCreationLocationStringified = TypeHelper::Stringify(deviceCreationLocation);
                                 output.WritePerformanceDataToCSV(
                                     profiler,
                                     args.NumIterations(),
                                     path,
-                                    TypeHelper::Stringify(deviceType),
-                                    TypeHelper::Stringify(inputDataType),
-                                    TypeHelper::Stringify(inputBindingType),
-                                    TypeHelper::Stringify(deviceCreationLocation),
+                                    deviceTypeStringified,
+                                    inputDataTypeStringified,
+                                    inputBindingTypeStringified,
+                                    deviceCreationLocationStringified,
                                     args.IsIgnoreFirstRun()
                                 );
                             }


### PR DESCRIPTION
Fix build error by declaring strings in variables before passing into function that accepts it as reference.