### PR TITLE
explicitly define the cpp language standard for manual tensorization

### DIFF
--- a/Samples/CustomTensorization/CustomTensorization/manual-tensorization.vcxproj
+++ b/Samples/CustomTensorization/CustomTensorization/manual-tensorization.vcxproj
@@ -60,6 +60,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
There is a bug in visual studio where the language standard doesn't get persisted to the vcxproj file which is causing the manual tensorization project to fail when building remotely in pipeline.