### PR TITLE
User/orilevari/public samples build artifacts

### DIFF
--- a/templates/build.yml
+++ b/templates/build.yml
@@ -58,22 +58,6 @@ jobs:
 
     condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
-
- # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
-  - task: PublishBuildArtifacts@1
-
-    displayName: 'Publish Artifact: Samples'
-
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: WinMLPublicSamples
-
-    condition: succeededOrFailed()
-
   - task: VSBuild@1
 
     displayName: 'Build CustomOperatorCPU Sample '
@@ -216,5 +200,19 @@ jobs:
 
     condition: succeededOrFailed()
 
+  - task: CopyFiles@2
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
 
+ # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
+  - task: PublishBuildArtifacts@1
+
+    displayName: 'Publish Artifact: Samples'
+
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: WinMLPublicSamples
+
+    condition: succeededOrFailed()
 

--- a/templates/build.yml
+++ b/templates/build.yml
@@ -202,18 +202,19 @@ jobs:
 
     condition: succeededOrFailed()
 
-# publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
-#  - task: PublishBuildArtifacts@1
-#
-#    displayName: 'Publish Artifact: Samples'
-#
-#    inputs:
-#
-#      pathtoPublish: '$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
-#      artifactName: WinMLPublicSamples
-#      parallel: true
-#      parallelCount: 8
-#
-#
-#    condition: succeededOrFailed()
+  - task: CopyFiles@2
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+      sourceFolder: 'Samples/AdapterSelection/${{ parameters.BuildPlatform }}/${{ parameters.BuildConfiguration }}/'
+
+ # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
+  - task: PublishBuildArtifacts@1
+
+    displayName: 'Publish Artifact: Samples'
+
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: WinMLPublicSamples
+
+    condition: succeededOrFailed()
 

--- a/templates/build.yml
+++ b/templates/build.yml
@@ -43,6 +43,39 @@ jobs:
 
   - task: VSBuild@1
 
+    displayName: 'Build AdapterSelection Sample '
+
+    inputs:
+
+      solution: Samples/AdapterSelection/AdapterSelection.sln
+      vsVersion: 15.0
+      msbuildArgs: '/p:AppxPackageSigningEnabled=false -v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
+      platform: '${{ parameters.BuildPlatform }}'
+      configuration: '${{ parameters.BuildConfiguration }}'
+      clean: true
+      msbuildArchitecture: x64
+      createLogFile: true
+
+    condition: succeededOrFailed()
+    
+  - task: CopyFiles@2
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+      sourceFolder: 'Samples/AdapterSelection/${{ parameters.BuildPlatform }}/${{ parameters.BuildConfiguration }}/'
+
+ # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
+  - task: PublishBuildArtifacts@1
+
+    displayName: 'Publish Artifact: Samples'
+
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: WinMLPublicSamples
+
+    condition: succeededOrFailed()
+
+  - task: VSBuild@1
+
     displayName: 'Build CustomOperatorCPU Sample '
 
     inputs:
@@ -166,25 +199,6 @@ jobs:
 
     condition: succeededOrFailed()
 
-
-  - task: VSBuild@1
-
-    displayName: 'Build AdapterSelection Sample '
-
-    inputs:
-
-      solution: Samples/AdapterSelection/AdapterSelection.sln
-      vsVersion: 15.0
-      msbuildArgs: '/p:AppxPackageSigningEnabled=false -v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
-      platform: '${{ parameters.BuildPlatform }}'
-      configuration: '${{ parameters.BuildConfiguration }}'
-      clean: true
-      msbuildArchitecture: x64
-      createLogFile: true
-
-    condition: succeededOrFailed()
-
-
   - task: VSBuild@1
 
     displayName: 'Build Emoji Sample'
@@ -202,19 +216,5 @@ jobs:
 
     condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-      sourceFolder: 'Samples/AdapterSelection/${{ parameters.BuildPlatform }}/${{ parameters.BuildConfiguration }}/'
 
- # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
-  - task: PublishBuildArtifacts@1
-
-    displayName: 'Publish Artifact: Samples'
-
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: WinMLPublicSamples
-
-    condition: succeededOrFailed()
 

--- a/templates/build.yml
+++ b/templates/build.yml
@@ -57,11 +57,11 @@ jobs:
       createLogFile: true
 
     condition: succeededOrFailed()
-    
+
   - task: CopyFiles@2
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)'
-      sourceFolder: 'Samples/AdapterSelection/${{ parameters.BuildPlatform }}/${{ parameters.BuildConfiguration }}/'
+      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\${{ parameters.BuildPlatform }}\${{ parameters.BuildConfiguration }}\'
 
  # publish build artifacts is failing for various platform/configurations non-deterministically. commenting out of master for now
   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Copying build artifacts to staging directory before publishing. For some reasons this fixed a previous error that would nondeterministically fail when uploading the emoji sample artifacts.