### PR TITLE
Make the target platform version attributes overridable

### DIFF
--- a/Samples/AdapterSelection/AdapterSelection/cpp/AdapterSelection.vcxproj
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/AdapterSelection.vcxproj
@@ -31,7 +31,8 @@
     <ProjectGuid>{2E115EFB-F7EC-444E-A555-507D55A89BC9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AdapterSelection</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ProjectName>AdapterSelection</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Samples/SqueezeNetObjectDetection/UWP/js/SqueezeNetObjectDetectionJS.jsproj
+++ b/Samples/SqueezeNetObjectDetection/UWP/js/SqueezeNetObjectDetectionJS.jsproj
@@ -48,7 +48,7 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\$(WMSJSProjectDirectory)\Microsoft.VisualStudio.$(WMSJSProject).props" />
   <PropertyGroup>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == ''">10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>$(VersionNumberMajor).$(VersionNumberMinor)</MinimumVisualStudioVersion>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
This will allow configuring a build of these samples on a different windows sdk