### PR TITLE
Explicit DLL loading for Windows.Ai.MachineLearning.dll and DirectML.dll

### DIFF
--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -43,7 +43,12 @@ Required command-Line arguments:
 -Debug                   : Will start a trace logging session.
 -Terse                   : Will suppress repetitive console output (initial iteration and summary info will be output).
 -AutoScale <mode>        : Will automatically scale an input image to match the required input dimensions of the model.  Pass in the interpolation mode, one of ["Nearest", "Linear", "Cubic", "Fant"].
-
+-LoadWinMLFromLocal optional:<fully qualified path> Loads Windows.Ai.MachineLearning.dll from optionally defined folder path.
+  If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.
+  WARNING: DirectML.dll needs to be in the same directory as Windows.Ai.MachineLearning.dll
+           or DirectML.dll will be loaded through the system by default.
+-LoadDirectMLFromLocal optional:<fully qualified path> Loads DirectML.dll from optionally defined folder path.
+   If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.
  ```
 
 Note that -CPU, -GPU, -GPUHighPerformance, -GPUMinPower -BGR, -RGB, -tensor, -CPUBoundInput, -GPUBoundInput are not mutually exclusive (i.e. you can combine as many as you want to run the model with different configurations).

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -45,8 +45,7 @@ Required command-Line arguments:
 -AutoScale <mode>        : Will automatically scale an input image to match the required input dimensions of the model.  Pass in the interpolation mode, one of ["Nearest", "Linear", "Cubic", "Fant"].
 -LoadWinMLFromLocal optional:<fully qualified path> Loads Windows.Ai.MachineLearning.dll from optionally defined folder path.
   If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.
-  WARNING: DirectML.dll needs to be in the same directory as Windows.Ai.MachineLearning.dll
-           or DirectML.dll will be loaded through the system by default.
+  WARNING:  DirectML.dll will be loaded through the system by default if -LoadDirectMLFromLocal isn't specified.
 -LoadDirectMLFromLocal optional:<fully qualified path> Loads DirectML.dll from optionally defined folder path.
    If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.
  ```

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -37,8 +37,7 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -AutoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
     std::cout << "  -LoadWinMLFromLocal optional:<fully qualified path> Loads Windows.Ai.MachineLearning.dll from optionally defined folder path." << std::endl;
     std::cout << "    If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe." << std::endl;
-    std::cout << "    WARNING: DirectML.dll needs to be in the same directory as Windows.Ai.MachineLearning.dll" << std::endl;
-    std::cout << "             or DirectML.dll will be loaded through the system by default."<< std::endl;
+    std::cout << "    WARNING: DirectML.dll will be loaded through the system by default if -LoadDirectMLFromLocal isn't specified."<< std::endl;
     std::cout << "  -LoadDirectMLFromLocal optional:<fully qualified path> Loads DirectML.dll from optionally defined folder path." << std::endl;
     std::cout << "    If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe." << std::endl;
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -6,7 +6,6 @@
 #include <apiquery2.h>
 
 using namespace Windows::AI::MachineLearning;
-bool g_loadWinMLDllFromLocal = false; //global flag to check if user wants to load Windows.AI.MachineLearning.dll from local directory.
 std::wstring g_loadWinMLDllPath = L""; //If user wants to load Windows.AI.MachineLearning.dll from specific local directory, this will hold the DLL path.
 void CommandLineArgs::PrintUsage() {
     std::cout << "WinML Runner" << std::endl;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -29,6 +29,7 @@ public:
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
     UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
+    const std::wstring& DirectMLLocalPath() const { return m_directLocalPath; }
 
     bool UseRGB() const
     {
@@ -127,13 +128,14 @@ private:
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
     UINT m_adapterIndex = -1;
     bool m_saveTensor = false;
-    std::string m_saveTensorMode = "First";
 
+    std::string m_saveTensorMode = "First";
     std::wstring m_modelFolderPath;
     std::wstring m_modelPath;
     std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
     std::wstring m_perfOutputPath;
+    std::wstring m_directLocalPath = L"";
     uint32_t m_numIterations = 1;
 };

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -28,7 +28,6 @@
 #include "TypeHelper.h"
 #include "TimerHelper.h"
 
-extern bool g_loadDllFromLocal;
 extern std::wstring g_loadWinMLDllPath;
 
 enum WINML_MODEL_TEST_PERF

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -24,6 +24,9 @@
 #include "TypeHelper.h"
 #include "TimerHelper.h"
 
+extern bool g_loadDllFromLocal;
+extern std::wstring g_loadWinMLDllPath;
+
 enum WINML_MODEL_TEST_PERF
 {
 	ENTIRE_TEST = 0,

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -141,7 +141,7 @@ public:
             }
             DXGI_ADAPTER_DESC1 pDesc;
             spAdapter->GetDesc1(&pDesc);
-            printf("Index: %d, Description: %ls\n", i, pDesc.Description);
+            printf("Adapter Index: %d, Description: %ls\n", i, pDesc.Description);
         }
     }
 

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -627,6 +627,10 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
     // CPU and GPU.
     profiler.Enable();
 
+    //If Windows.AI.MachineLearning.dll or DirectML's local path was specified then print it out
+    std::wcout << L"Windows.AI.MachineLearning.dll location: " << (!g_loadWinMLDllPath.empty() ? g_loadWinMLDllPath : L"Will load from system as needed") << std::endl;
+    std::wcout << L"Directml.dll location: " << (!args.DirectMLLocalPath().empty() ? args.DirectMLLocalPath() : L"Will load from system as needed") << std::endl;
+
     if (!args.OutputPath().empty())
     {
         output.SetCSVFileName(args.OutputPath());

--- a/Tools/WinMLRunner/src/dllload.cpp
+++ b/Tools/WinMLRunner/src/dllload.cpp
@@ -26,26 +26,14 @@ int32_t __stdcall WINRT_RoGetActivationFactory(void* classId, winrt::guid const&
     std::wstring_view name{ WindowsGetStringRawBuffer(static_cast<HSTRING>(classId), nullptr), WindowsGetStringLen(static_cast<HSTRING>(classId)) };
     HMODULE library{ nullptr };
 
-    if (starts_with(name, L"Windows.AI.MachineLearning.") && g_loadDllFromLocal) //If we want to load Windows.Ai.MachineLearning.dll from local path
+    if (starts_with(name, L"Windows.AI.MachineLearning.") && !g_loadWinMLDllPath.empty()) //If we want to load Windows.Ai.MachineLearning.dll from local path
     {
-        if (g_loadWinMLDllPath.empty()) //If no path was specified, we get the dll from the same directory as WinMLRunner.exe
-        {
-            library = LoadLibraryW((FileHelper::GetModulePath() + L"Windows.AI.MachineLearning.dll").c_str());
-            if (!library)
-            {
-                std::cout << "ERROR: Loading Windows.Ai.MachineLearning.dll from local failed! Check if it is contained in the same directory." << std::endl;
-                return HRESULT_FROM_WIN32(GetLastError());
-            }
-        }
-        else //Otherwise, we get the dll from the path that was specified.
-        {
             library = LoadLibraryW(g_loadWinMLDllPath.c_str());
             if (!library)
             {
-                std::cout << "ERROR: Loading Windows.Ai.MachineLearning.dll from local failed! Check if it is contained in the path that was specified." << std::endl;
+                std::cout << "ERROR: Loading Windows.AI.MachineLearning.dll from local failed! Check if it is contained in the path that was specified." << std::endl;
                 return HRESULT_FROM_WIN32(GetLastError());
             }
-        }
     }
     else //If we don't want to load Windows.Ai.MachineLearning.dll from local path, then it will go through the OS normally.
     {


### PR DESCRIPTION
This change makes it so that WinMLRunner explicitly needs to specify if the user wants to specifically load Windows.AI.MachineLearning.dll or DirectML.dll in a custom path.

By default, it will load Windows.Ai.MachineLearning.dll and DirectML.dll from System32 unless -LoadWinMLFromLocal or -LoadDirectMLFromLocal flag are specified.

Usage: 
-LoadWinMLFromLocal optional:<fully qualified path> Loads Windows.Ai.MachineLearning.dll from optionally defined folder path.
 If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.
 WARNING: DirectML.dll will be loaded through the system by default if -LoadDirectMLFromLocal isn't specified.


-LoadDirectMLFromLocal optional:<fully qualified path> Loads DirectML.dll from optionally defined folder path.
  If path isn't specified then the DLL will be loaded from the same directory as WinMLRunner.exe.