### PR TITLE
add back targetplatformminversion attribute

### DIFF
--- a/Samples/SqueezeNetObjectDetection/UWP/js/SqueezeNetObjectDetectionJS.jsproj
+++ b/Samples/SqueezeNetObjectDetection/UWP/js/SqueezeNetObjectDetectionJS.jsproj
@@ -49,6 +49,7 @@
   <PropertyGroup>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>$(VersionNumberMajor).$(VersionNumberMinor)</MinimumVisualStudioVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageCertificateKeyFile>SqueezeNetObjectDetection_TemporaryKey.pfx</PackageCertificateKeyFile>


### PR DESCRIPTION
I needed to add back the targetplatformminversion attribute to get the UWP JavaScript to start building successfully again.