### PR TITLE
User/orilevari/tensorization paths

### DIFF
--- a/Samples/CustomTensorization/CustomTensorization/CustomTensorization.vcxproj
+++ b/Samples/CustomTensorization/CustomTensorization/CustomTensorization.vcxproj
@@ -113,11 +113,15 @@
     <ClCompile Include="TensorConvertor.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="fns-candy.onnx" />
+    <CopyFileToFolders Include="fns-candy.onnx">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Image Include="fish_720.png" />
+    <CopyFileToFolders Include="fish_720.png">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Samples/CustomTensorization/CustomTensorization/CustomTensorization.vcxproj.filters
+++ b/Samples/CustomTensorization/CustomTensorization/CustomTensorization.vcxproj.filters
@@ -38,13 +38,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="fns-candy.onnx">
-      <Filter>Resource Files</Filter>
-    </None>
   </ItemGroup>
   <ItemGroup>
-    <Image Include="fish_720.png">
+    <CopyFileToFolders Include="fish_720.png">
       <Filter>Resource Files</Filter>
-    </Image>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="fns-candy.onnx">
+      <Filter>Resource Files</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
@@ -20,7 +20,7 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 namespace TensorizationHelper
 {
-    std::wstring GetModulePath(bool visiblePath)
+    std::wstring GetModulePath()
     {
         std::wstring val;
         wchar_t modulePath[MAX_PATH] = { 0 };
@@ -33,16 +33,20 @@ namespace TensorizationHelper
 
         val = drive;
         val += dir;
-		if (visiblePath) {
-			int32_t i = val.find(filename);
-			// only return the modified path when there is a parent folder which contains a CustomTensorization folder
-			// This will match when a user is running this sample in the repository's directory structure
-			if (i != std::wstring::npos) {
-				val = val.substr(0, i + wcslen(filename)) + L"\\" + filename + L"\\";
-			}
-		}
         return val;
     }
+
+	std::wstring GetFileName()
+	{
+		wchar_t modulePath[MAX_PATH] = { 0 };
+		GetModuleFileNameW((HINSTANCE)&__ImageBase, modulePath, _countof(modulePath));
+		wchar_t drive[_MAX_DRIVE];
+		wchar_t dir[_MAX_DIR];
+		wchar_t filename[_MAX_FNAME];
+		wchar_t ext[_MAX_EXT];
+		errno_t err = _wsplitpath_s(modulePath, drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, ext, _MAX_EXT);
+		return std::wstring(filename);
+	}
 
     TensorFloat SoftwareBitmapToSoftwareTensor(SoftwareBitmap softwareBitmap)
     {

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
@@ -33,7 +33,6 @@ namespace TensorizationHelper
 
         val = drive;
         val += dir;
-		printf("unmodified string: %ls\n", val.c_str());
 		if (visiblePath) {
 			int32_t i = val.find(filename);
 			// only return the modified path when there is a parent folder which contains a CustomTensorization folder

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.cpp
@@ -20,7 +20,7 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 namespace TensorizationHelper
 {
-    std::wstring GetModulePath()
+    std::wstring GetModulePath(bool visiblePath)
     {
         std::wstring val;
         wchar_t modulePath[MAX_PATH] = { 0 };
@@ -33,8 +33,15 @@ namespace TensorizationHelper
 
         val = drive;
         val += dir;
-        int32_t i = val.find(filename);
-        val = val.substr(0, i + wcslen(filename)) + L"\\" + filename + L"\\";
+		printf("unmodified string: %ls\n", val.c_str());
+		if (visiblePath) {
+			int32_t i = val.find(filename);
+			// only return the modified path when there is a parent folder which contains a CustomTensorization folder
+			// This will match when a user is running this sample in the repository's directory structure
+			if (i != std::wstring::npos) {
+				val = val.substr(0, i + wcslen(filename)) + L"\\" + filename + L"\\";
+			}
+		}
         return val;
     }
 

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
@@ -10,8 +10,8 @@ namespace TensorizationHelper
     std::wstring GetFileName();
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToSoftwareTensor(
-        winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);
+    winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToDX12Tensor(
-        winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);
+    winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);
 }

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
@@ -6,7 +6,7 @@
 
 namespace TensorizationHelper
 {
-    std::wstring GetModulePath();
+    std::wstring GetModulePath(bool grandparentPath);
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToSoftwareTensor(
         winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
@@ -6,7 +6,7 @@
 
 namespace TensorizationHelper
 {
-    std::wstring GetModulePath(bool grandparentPath);
+    std::wstring GetModulePath(bool visiblePath);
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToSoftwareTensor(
         winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
@@ -7,7 +7,7 @@
 namespace TensorizationHelper
 {
     std::wstring GetModulePath();
-	std::wstring GetFileName();
+    std::wstring GetFileName();
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToSoftwareTensor(
         winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);

--- a/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
+++ b/Samples/CustomTensorization/CustomTensorization/TensorConvertor.h
@@ -6,7 +6,8 @@
 
 namespace TensorizationHelper
 {
-    std::wstring GetModulePath(bool visiblePath);
+    std::wstring GetModulePath();
+	std::wstring GetFileName();
 
     winrt::Windows::AI::MachineLearning::TensorFloat SoftwareBitmapToSoftwareTensor(
         winrt::Windows::Graphics::Imaging::SoftwareBitmap softwareBitmap);

--- a/Samples/CustomTensorization/CustomTensorization/main.cpp
+++ b/Samples/CustomTensorization/CustomTensorization/main.cpp
@@ -18,9 +18,7 @@ LearningModel model = nullptr;
 LearningModelSession session = nullptr;
 LearningModelBinding binding = nullptr;
 
-const hstring modulePath{ TensorizationHelper::GetModulePath(false).c_str() };
-const hstring visibleModulePath{ TensorizationHelper::GetModulePath(true).c_str() };
-
+const wstring modulePath{ TensorizationHelper::GetModulePath() };
 
 // Forward declarations
 void LoadModel(hstring modelPath);
@@ -36,8 +34,8 @@ void SaveOutputToDisk(
 int main()
 {
     init_apartment();
-    const hstring modelPath = modulePath + L"fns-candy.onnx";
-    const hstring imagePath = modulePath + L"fish_720.png";
+    const hstring modelPath = static_cast<hstring>(modulePath.c_str()) + L"fns-candy.onnx";
+    const hstring imagePath = static_cast<hstring>(modulePath.c_str()) + L"fish_720.png";
 
     // The second parameter of BindModel specifies manually tensorization on which device.
     // Mannually-tensorization from CPU
@@ -159,7 +157,17 @@ void SaveOutputToDisk(
     hstring outputDataImageFileName)
 {
     // save the output to disk
-    StorageFolder currentfolder = StorageFolder::GetFolderFromPathAsync(visibleModulePath).get();
+
+	// try and see if we can output the pngs to the more visible folder where the vcxproj file is located
+	// otherwise output next to the executable
+	std::wstring outputPath = modulePath;
+	std::wstring filename{ TensorizationHelper::GetFileName() };
+	int32_t i = modulePath.find(filename);
+	if (i != std::wstring::npos) {
+		outputPath = outputPath.substr(0, i + wcslen(filename.c_str())) + L"\\" + filename + L"\\";
+	}
+
+    StorageFolder currentfolder = StorageFolder::GetFolderFromPathAsync(outputPath).get();
     StorageFile outimagefile = currentfolder.CreateFileAsync(outputDataImageFileName, CreationCollisionOption::ReplaceExisting).get();
     IRandomAccessStream writestream = outimagefile.OpenAsync(FileAccessMode::ReadWrite).get();
     BitmapEncoder encoder = BitmapEncoder::CreateAsync(BitmapEncoder::JpegEncoderId(), writestream).get();

--- a/Samples/CustomTensorization/CustomTensorization/main.cpp
+++ b/Samples/CustomTensorization/CustomTensorization/main.cpp
@@ -18,7 +18,8 @@ LearningModel model = nullptr;
 LearningModelSession session = nullptr;
 LearningModelBinding binding = nullptr;
 
-const hstring modulePath{ TensorizationHelper::GetModulePath().c_str()};
+const hstring modulePath{ TensorizationHelper::GetModulePath(false).c_str() };
+const hstring visibleModulePath{ TensorizationHelper::GetModulePath(true).c_str() };
 
 
 // Forward declarations
@@ -158,7 +159,7 @@ void SaveOutputToDisk(
     hstring outputDataImageFileName)
 {
     // save the output to disk
-    StorageFolder currentfolder = StorageFolder::GetFolderFromPathAsync(modulePath).get();
+    StorageFolder currentfolder = StorageFolder::GetFolderFromPathAsync(visibleModulePath).get();
     StorageFile outimagefile = currentfolder.CreateFileAsync(outputDataImageFileName, CreationCollisionOption::ReplaceExisting).get();
     IRandomAccessStream writestream = outimagefile.OpenAsync(FileAccessMode::ReadWrite).get();
     BitmapEncoder encoder = BitmapEncoder::CreateAsync(BitmapEncoder::JpegEncoderId(), writestream).get();


### PR DESCRIPTION
This modifies the way that the custom tensorization sample resolves it's paths to ingest and output files.

Previously it would rely on its input files (.onnx and .png) to exist in a directory that was resolved in a way that would crash if the executable was not located in a directory which had a parent directory containing a subdirectory with the name CustomTensorization. This was posing a problem for setting up build artifacts to test against.

Now, these input files are copied on build and searched for in the same directory as the executable. Furthermore, the old path resolving mechanism is used for the output files if and only if that parent directory exists, otherwise files will be output in the same directory as the executable.

This preserves the functionality originally intended when the sample is run in the context of this repository, which was to make sure it is easy for users to locate the output files by placing them next to the vcxproj file.