### PR TITLE
Print Memory Peak Working Set Usage

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.vcxproj
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.vcxproj
@@ -97,6 +97,7 @@
       <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -112,6 +113,7 @@
       <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -130,6 +132,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -150,6 +153,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -276,7 +280,7 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-        <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1.csv">
+    <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1.csv">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
@@ -287,7 +291,7 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-        <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1Csv.csv">
+    <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1Csv.csv">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
@@ -298,7 +302,7 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-        <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1Garbage.csv">
+    <Content Include="..\..\SharedContent\media\softmaxout1GpuIteration1Garbage.csv">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
@@ -309,8 +313,6 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-
-
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include "CommandLineArgs.h"
 #include <apiquery2.h>
+#include <ctime>
+#include <iomanip>
 
 using namespace Windows::AI::MachineLearning;
 
@@ -190,6 +192,21 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
             {
                 PrintUsage();
                 throw hresult_invalid_argument(L"Unknown Mode!");
+            }
+            try
+            {
+                // This is to check for second optional value for -SaveTensorData to specify path
+                CheckNextArgument(args, i);
+                SetTensorOutputPath(args[++i].c_str());
+            }
+            catch (...) {
+                // set to default path
+                auto time = std::time(nullptr);
+                struct tm localTime;
+                localtime_s(&localTime, &time);
+                std::wostringstream oss;
+                oss << std::put_time(&localTime, L"%Y-%m-%d_%H.%M.%S");
+                SetTensorOutputPath(L"\\PerIterationRun[" + oss.str() + L"]");
             }
         }
         else if (_wcsicmp(args[i].c_str(), L"-version") == 0)

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -29,6 +29,7 @@ public:
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
+    const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
     UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
 
     bool UseRGB() const
@@ -96,6 +97,7 @@ public:
 
 
     void SetModelPath(const std::wstring& modelPath) { m_modelPath = modelPath; }
+    void SetTensorOutputPath(const std::wstring& tensorOutputPath) { m_tensorOutputPath = tensorOutputPath; }
     void SetInputDataPath(const std::wstring& inputDataPath) { m_inputData = inputDataPath; }
     void SetNumThreads(unsigned numThreads) { m_numThreads = numThreads; }
     void SetThreadInterval(unsigned threadInterval) { m_threadInterval = threadInterval; }
@@ -143,6 +145,7 @@ private:
     std::wstring m_csvData;
     std::wstring m_inputData;
     std::wstring m_perfOutputPath;
+    std::wstring m_tensorOutputPath;
     uint32_t m_numIterations = 1;
     uint32_t m_numThreads = 1;
     uint32_t m_threadInterval = 0;

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -284,6 +284,7 @@ public:
             std::cout << std::endl;
         }
         std::cout << "  Working Set Memory usage (evaluate): " << firstEvalMemoryUsage << " MB" << std::endl;
+        std::cout << "  Working Set Memory usage (load, bind, session creation, and evaluate): " << firstIterationWorkingSetMemoryUsage << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)
         {
@@ -293,7 +294,6 @@ public:
             std::cout << "  Peak Working Set Memory Difference (from bind to evaluate): " << firstEvalPeakMemoryUsage << " MB" << std::endl;
         }
 
-        std::cout << "  Working Set Memory usage (load, bind, session creation, and evaluate): " << firstIterationWorkingSetMemoryUsage << " MB" << std::endl;
         std::cout << "  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): " << firstIterationPeakWorkingSet << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -288,6 +288,7 @@ public:
 
         if (isPerformanceConsoleOutputVerbose)
         {
+            std::cout << std::endl;
             std::cout << "  Peak Working Set Memory Difference (from start to load): " << firstLoadPeakWorkingSetUsage << " MB" << std::endl;
             std::cout << "  Peak Working Set Memory Difference (from model load to session creation): " << firstSessionPeakWorkingSetUsage << " MB" << std::endl;
             std::cout << "  Peak Working Set Memory Difference (from session to bind): " << firstBindPeakMemoryUsage << " MB" << std::endl;

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -501,16 +501,10 @@ public:
         m_outputTensorHash[iterationNum] = hashcode;
     }
     
-    void SetDefaultPerIterationFolder()
+    void SetDefaultPerIterationFolder(const std::wstring &folderName)
     {
-        auto time = std::time(nullptr);
-        struct tm localTime;
-        localtime_s(&localTime, &time);
-        std::string cur_dir = _getcwd(NULL, 0);
-        std::ostringstream oss;
-        oss << std::put_time(&localTime, "%Y-%m-%d_%H.%M.%S");
-        std::string folderName = "\\PerIterationRun[" + oss.str() + "]";
-        m_folderNamePerIteration = cur_dir + folderName;
+        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+        m_folderNamePerIteration = converter.to_bytes(folderName);
         if (_mkdir(m_folderNamePerIteration.c_str()) != 0)
             std::cout << "Folder cannot be created";
     }

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -200,20 +200,24 @@ public:
         double firstLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
         double firstLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double firstLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstLoadPeakWorkingSetUsage = profiler[LOAD_MODEL].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double firstSessionCreationWorkingSetMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
         double firstSessionCreationSharedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double firstSessionCreationDedicatedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstSessionPeakWorkingSetUsage = profiler[CREATE_SESSION].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageBindMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::WORKING_SET_USAGE);
         double minBindMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::WORKING_SET_USAGE);
         double maxBindMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::WORKING_SET_USAGE);
         double firstBindMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double firstBindPeakMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageEvalMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
         double minEvalMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::WORKING_SET_USAGE);
         double maxEvalMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::WORKING_SET_USAGE);
         double firstEvalMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double firstEvalPeakMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
@@ -253,6 +257,8 @@ public:
             profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE) +
             profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
+        double firstIterationPeakWorkingSet = firstLoadPeakWorkingSetUsage + firstSessionPeakWorkingSetUsage + firstBindPeakMemoryUsage + firstEvalPeakMemoryUsage;
+
         printf("\nResults (device = %s, numIterations = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s):\n",
             TypeHelper::Stringify(deviceType).c_str(),
             numIterations,
@@ -278,7 +284,17 @@ public:
             std::cout << std::endl;
         }
         std::cout << "  Working Set Memory usage (evaluate): " << firstEvalMemoryUsage << " MB" << std::endl;
+
+        if (isPerformanceConsoleOutputVerbose)
+        {
+            std::cout << "  Peak Working Set Memory Difference (from start to load): " << firstLoadPeakWorkingSetUsage << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from model load to session creation): " << firstSessionPeakWorkingSetUsage << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from session to bind): " << firstBindPeakMemoryUsage << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from bind to evaluate): " << firstEvalPeakMemoryUsage << " MB" << std::endl;
+        }
+
         std::cout << "  Working Set Memory usage (load, bind, session creation, and evaluate): " << firstIterationWorkingSetMemoryUsage << " MB" << std::endl;
+        std::cout << "  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): " << firstIterationPeakWorkingSet << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)
         {

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -661,7 +661,7 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 
     if (args.IsSaveTensor() || args.IsPerIterationCapture())
     {
-        output.SetDefaultPerIterationFolder();
+        output.SetDefaultPerIterationFolder(args.TensorOutputPath());
         output.SetDefaultCSVFileNamePerIteration();
     }
 

--- a/Tools/WinMLRunner/src/TimerHelper.h
+++ b/Tools/WinMLRunner/src/TimerHelper.h
@@ -129,7 +129,8 @@ public:
 
 private:
 
-    bool GetProcessMemoryCounters(DWORD pid, ULONG& pageFaultCount, SIZE_T& pageFileUsage, SIZE_T& peakPageFileUsage, SIZE_T& workingSetSize, SIZE_T& peakWorkingSetSize)
+    bool GetProcessMemoryCounters(DWORD pid, ULONG& pageFaultCount, SIZE_T& pageFileUsage, SIZE_T& peakPageFileUsage,
+        SIZE_T& workingSetSize, SIZE_T& peakWorkingSetSize)
     {
         HANDLE hProcess = NULL;
 


### PR DESCRIPTION
This is to print out peak working set of a process. 

Examples of memory perf output with this change

**-perf all**

  Working Set Memory usage (load): 564.152 MB
  Working Set Memory usage (session creation): 1061.62 MB
  Working Set Memory usage (bind): 0.410156 MB
  Working Set Memory usage (evaluate): 1.61719 MB
  Peak Working Set Memory Difference (from start to load): 563.926 MB
  Peak Working Set Memory Difference (from model load to session creation): 1609.46 MB
  Peak Working Set Memory Difference (from session to bind): 0 MB
  Peak Working Set Memory Difference (from bind to evaluate): 0 MB
  Working Set Memory usage (load, bind, session creation, and evaluate): 1627.8 MB
  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): 2173.39 MB

**-perf **
  Working Set Memory usage (evaluate): 1.60547 MB
  Working Set Memory usage (load, bind, session creation, and evaluate): 1627.78 MB
  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): 2173.6 MB
