### PR TITLE
Remove DXCore from WInMLRunner

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.vcxproj
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{E9D4AC92-8295-4FB4-BF7D-3FAF74B564E8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinMLRunnerTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18323.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -16,7 +16,7 @@ You can either download the x64 executable or build it yourself.
 #### Prerequisites
 - [Visual Studio 2017 Version 15.7.4 or Newer](https://developer.microsoft.com/en-us/windows/downloads)
 - [Windows 10 - Build 17763 or higher](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewiso)
-- [Windows SDK - Build 18323 or higher](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewSDK)
+- [Windows SDK - Build 17763 or higher](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewSDK)
 
 The easiest way to use these samples without using Git is to download the zip file containing the current version (using the following link or by clicking the "Download ZIP" button on the repo page). You can then unzip the entire archive and use the samples in Visual Studio 2017. Notes: Before you unzip the archive, right-click it, select Properties, and then select Unblock.
 Be sure to unzip the entire archive, and not just individual samples. The samples all depend on the SharedContent folder in the archive. In Visual Studio 2017, the platform target defaults to ARM, so be sure to change that to x64 or x86 if you want to test on a non-ARM device. Reminder: If you unzip individual samples, they will not build due to references to other portions of the ZIP file that were not unzipped. 
@@ -37,7 +37,6 @@ Required command-Line arguments:
 -GPU                     : Will create a session on the GPU.
 -GPUHighPerformance      : Will create a session with the most powerful GPU device available.
 -GPUMinPower             : Will create a session with GPU with the least power.
--GPUAdapterIndex : run model on GPU specified by its index in DXGI enumeration. NOTE: Please only use this flag on DXCore supported machines.
 -CreateDeviceOnClient    : Will create the device on the client and explicitly pass it to WinML via the API. GPU runs using this flag will usually be faster than -CreateDeviceInWinML since we avoid a cross-device copy by creating the video frame on the same device that DML uses to bind inputs.
 -CreateDeviceInWinML     : Will create the device inside WinML. GPU runs using this flag will usually be slower than -CreateDeviceOnClient since we have to copy the video frame to a different device.
 -CPUBoundInput           : Will bind the input to the CPU.

--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -48,7 +48,7 @@
     <ProjectGuid>{31653A2F-02CC-4A95-9880-BF86965FB262}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinMLRunner</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18323.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -77,7 +77,6 @@
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsAppContainer>false</WindowsAppContainer>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -148,7 +147,6 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <ShowIncludes>true</ShowIncludes>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>
@@ -159,14 +157,8 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)src\GenerateVersionStrings.cmd $(ProjectDir) $(IntDir)</Command>
@@ -187,18 +179,11 @@
       </PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -223,14 +208,8 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -247,7 +226,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ShowIncludes>true</ShowIncludes>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>
@@ -257,16 +235,11 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
+      <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -293,16 +266,11 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
+      <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -329,16 +297,11 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
+      <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>mincore.lib;windowsapp.lib;d3d12.lib;dxgi.lib;d3d11.lib;onecore.lib</AdditionalDependencies>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <DelayLoadDLLs>dxgi.dll;d3d11.dll; ext-ms-win-dxcore-l1-1-0.dll</DelayLoadDLLs>
-      <IgnoreAllDefaultLibraries>
-      </IgnoreAllDefaultLibraries>
-      <IgnoreSpecificDefaultLibraries>kernel32.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)src\GenerateVersionStrings.cmd $(ProjectDir) $(IntDir)</Command>

--- a/Tools/WinMLRunner/WinMLRunnerScenarios.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunnerScenarios.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{C174D45D-C189-475B-B1A7-494939EE7491}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinMLRunnerScenarios</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18323.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj
@@ -48,7 +48,7 @@
     <ProjectGuid>{C3BCBEA1-90E6-426F-88AC-64C274BCEF45}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinMLRunnerStaticLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18323.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <iostream>
 #include "CommandLineArgs.h"
-#include <apiquery2.h>
 #include <ctime>
 #include <iomanip>
 
@@ -19,7 +18,6 @@ void CommandLineArgs::PrintUsage() {
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
-    std::cout << "  -GPUAdapterIndex : run model on GPU specified by its index in DXGI enumeration. NOTE: Please only use this flag on DXCore supported machines." << std::endl;
     std::cout << "  -CreateDeviceOnClient : create the device on the client and pass it to WinML" << std::endl;
     std::cout << "  -CreateDeviceInWinML : create the device inside WinML" << std::endl;
     std::cout << "  -CPUBoundInput : bind the input to the CPU" << std::endl;
@@ -72,18 +70,6 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
         else if ((_wcsicmp(args[i].c_str(), L"-GPUMinPower") == 0))
         {
             m_useGPUMinPower = true;
-        }
-        else if ((_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0) && i + 1 < args.size() && args[i + 1][0] != L'-')
-        {
-            CheckNextArgument(args, i);
-            HMODULE library{ nullptr };
-            library = LoadLibrary(L"ext-ms-win-dxcore-l1-1-0");
-            if (!library)
-            {
-                throw hresult_invalid_argument(L"ERROR: DXCORE isn't supported on this machine. GpuAdapterIndex flag should only be used with DXCore supported machines.");
-            }
-            m_useGPU = true;
-            m_adapterIndex = static_cast<UINT>(_wtoi(args[++i].c_str()));
         }
         else if ((_wcsicmp(args[i].c_str(), L"-CreateDeviceOnClient") == 0))
         {

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -30,7 +30,6 @@ public:
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
     const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
-    UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
 
     bool UseRGB() const
     {
@@ -135,7 +134,6 @@ private:
     bool m_autoScale = false;
     bool m_perfOutput = false;
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
-    UINT m_adapterIndex = -1;
     bool m_saveTensor = false;
     std::string m_saveTensorMode = "First";
 

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -2,8 +2,6 @@
 #ifndef _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 #endif
-#include <vcruntime.h>
-#include <windows.h>
 // unknown.h needs to be inlcuded before any winrt headers
 #include <unknwn.h>
 #include <winrt/Windows.AI.MachineLearning.h>
@@ -22,9 +20,7 @@
 #include <numeric>
 #include <cassert>
 #include <fstream>
-#include <Windows.AI.MachineLearning.Native.h>
 #include <dxgi1_6.h>
-#include <d3d12.h>
 #include "TypeHelper.h"
 #include "TimerHelper.h"
 #include "DirectXPackedVector.h"
@@ -86,15 +82,3 @@ inline void ThrowFailure(const std::wstring &errorMsg)
 {
 	throw errorMsg;
 }
-
-//
-// Delay load exception information
-//
-#ifndef FACILITY_VISUALCPP
-#define FACILITY_VISUALCPP  ((LONG)0x6d)
-#endif
-
-#define VcppException(sev,err)  ((sev) | (FACILITY_VISUALCPP<<16) | err)
-
-HRESULT CreateDXGIFactory2SEH(void **pIDXGIFactory);
-

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -7,11 +7,8 @@
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 #include "Run.h"
 #include "Scenarios.h"
-#include <initguid.h>
-#include <dxcore.h>
 
 #define THROW_IF_FAILED(hr) { if (FAILED(hr)) throw hresult_error(hr); }
-
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
 LearningModel LoadModel(const std::wstring &path, bool capturePerf, OutputHelper& output, const CommandLineArgs& args, uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
@@ -204,13 +201,11 @@ HRESULT EvaluateModel(
 
     LearningModelSession session = nullptr;
     IDirect3DDevice winrtDevice = nullptr;
-    com_ptr<::IUnknown> spUnkLearningModelDevice;
 
     try
     {
-        UINT adapterIndex = args.GetGPUAdapterIndex();
-
-        if (deviceCreationLocation == DeviceCreationLocation::ClientCode && deviceType != DeviceType::CPU)
+        if (deviceCreationLocation == DeviceCreationLocation::ClientCode
+            && deviceType != DeviceType::CPU)
         {
             // Enumerate Adapters to pick the requested one.
             com_ptr<IDXGIFactory6> factory;
@@ -260,85 +255,6 @@ HRESULT EvaluateModel(
             {
                 WINML_PROFILING_STOP(profiler, WINML_MODEL_TEST_PERF::CREATE_SESSION);
             }
-        }
-        else if ((TypeHelper::GetWinmlDeviceKind(deviceType) != LearningModelDeviceKind::Cpu) && (adapterIndex != -1))
-        {
-            HRESULT hr = S_OK;
-            IUnknown* pAdapter = NULL;
-            D3D_FEATURE_LEVEL d3dFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_1_0_CORE;
-            D3D12_COMMAND_LIST_TYPE commandQueueType = D3D12_COMMAND_LIST_TYPE_COMPUTE;
-
-            com_ptr<IDXCoreAdapterFactory> spFactory;
-
-            hr = DXCoreCreateAdapterFactory(__uuidof(IDXCoreAdapterFactory), spFactory.put_void());
-            THROW_IF_FAILED(hr);
-
-            com_ptr<IDXCoreAdapterList> spAdapterList;
-
-            const GUID dxGUIDs[] = { DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
-
-            hr = spFactory->GetAdapterList(dxGUIDs, ARRAYSIZE(dxGUIDs), spAdapterList.put());
-            THROW_IF_FAILED(hr);
-
-            com_ptr<IDXCoreAdapter> spAdapter;
-            hr = spAdapterList->GetItem(adapterIndex, spAdapter.put());
-            THROW_IF_FAILED(hr);
-
-            CHAR driverDescription[128];
-
-            spAdapter->QueryProperty(DXCoreProperty::DriverDescription, sizeof(driverDescription), driverDescription);
-            printf("Use adapter : %s\n", driverDescription);
-
-            pAdapter = spAdapter.get();
-
-            com_ptr<IDXGIAdapter> spDxgiAdapter;
-
-            if (spAdapter->IsDXAttributeSupported(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX))
-            {
-                d3dFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0;
-                commandQueueType = D3D12_COMMAND_LIST_TYPE_DIRECT;
-
-                com_ptr<IDXGIFactory4> dxgiFactory4;
-
-                try
-                {
-                    hr = CreateDXGIFactory2SEH(dxgiFactory4.put_void());
-                }
-                catch (...)
-                {
-                    hr = E_FAIL;
-                }
-
-                if (hr == S_OK)
-                {
-                    LUID adapterLuid;
-                    spAdapter->GetLUID(&adapterLuid);
-
-                    hr = dxgiFactory4->EnumAdapterByLuid(adapterLuid, __uuidof(IDXGIAdapter), spDxgiAdapter.put_void());
-                    if (hr == S_OK)
-                    {
-                        pAdapter = spDxgiAdapter.get();
-                    }
-                }
-            }
-
-            com_ptr<ID3D12Device> d3d12Device;
-            hr = D3D12CreateDevice(pAdapter, d3dFeatureLevel, __uuidof(ID3D12Device), d3d12Device.put_void());
-            THROW_IF_FAILED(hr);
-
-            com_ptr<ID3D12CommandQueue> d3d12CommandQueue;
-            D3D12_COMMAND_QUEUE_DESC commandQueueDesc = {};
-            commandQueueDesc.Type = commandQueueType;
-
-            hr = d3d12Device->CreateCommandQueue(&commandQueueDesc, __uuidof(ID3D12CommandQueue), d3d12CommandQueue.put_void());
-            THROW_IF_FAILED(hr);
-
-            auto factory = get_activation_factory<LearningModelDevice, ILearningModelDeviceFactoryNative>();
-
-            hr = factory->CreateFromD3D12CommandQueue(d3d12CommandQueue.get(), spUnkLearningModelDevice.put());
-            THROW_IF_FAILED(hr);
-
-            session = LearningModelSession(model, spUnkLearningModelDevice.as<LearningModelDevice>());
         }
         else
         {
@@ -617,23 +533,6 @@ std::vector<DeviceCreationLocation> FetchDeviceCreationLocations(const CommandLi
     return deviceCreationLocations;
 }
 
-HRESULT CreateDXGIFactory2SEH(void **pIDXGIFactory)
-{
-    HRESULT hr;
-
-    __try
-    {
-        hr = CreateDXGIFactory2(0, __uuidof(IDXGIFactory4), pIDXGIFactory);
-    }
-    __except (GetExceptionCode() == VcppException(ERROR_SEVERITY_ERROR, ERROR_MOD_NOT_FOUND) ?
-        EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
-    {
-        hr = HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
-    }
-
-    return hr;
-}
-
 int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     // Initialize COM in a multi-threaded environment.
@@ -658,8 +557,6 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
         output.SetDefaultPerIterationFolder(args.TensorOutputPath());
         output.SetDefaultCSVFileNamePerIteration();
     }
-
-    D3D12EnableExperimentalFeatures(1, &D3D12ComputeOnlyDevices, NULL, 0);
 
     if (!args.ModelPath().empty() || !args.FolderPath().empty())
     {

--- a/Tools/WinMLRunner/src/main.cpp
+++ b/Tools/WinMLRunner/src/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
     }
     try
     {
-        commandLineArgs =  new CommandLineArgs(argsList);
+        commandLineArgs = new CommandLineArgs(argsList);
     }
     catch (hresult_error hr)
     {


### PR DESCRIPTION
DXCore is no longer contained inside the Preview SDK so this functionality needs to be removed. With this change, WinMLRunner can now be built with (October 2017 Release SDK 17763)