### PR TITLE
Change binding data to not memset 0, make fp16 tensor tests more lenient

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -492,35 +492,6 @@ namespace WinMLRunnerTest
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(49), GetOutputCSVLineCount());
         }
-        TEST_METHOD(GarbageInputOnlyGpuSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU"});
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_garbage_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(GarbageInputOnlyCpuSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_garbage_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
-
-        TEST_METHOD(GarbageInputOnlyGpuSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_garbage_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(GarbageInputOnlyCpuSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_garbage_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
     };
 
     TEST_CLASS(ImageInputTest)

--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -200,7 +200,7 @@ namespace BindingUtilities
                 ModelBinding<float> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(float) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(float) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -215,7 +215,7 @@ namespace BindingUtilities
                 ModelBinding<float> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(float) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(float) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -230,7 +230,7 @@ namespace BindingUtilities
                 ModelBinding<double> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(double) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(double) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -245,7 +245,7 @@ namespace BindingUtilities
                 ModelBinding<uint8_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(uint8_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(uint8_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -260,7 +260,7 @@ namespace BindingUtilities
                 ModelBinding<uint8_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(uint8_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(uint8_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -275,7 +275,7 @@ namespace BindingUtilities
                 ModelBinding<int16_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(int16_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(int16_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -290,7 +290,7 @@ namespace BindingUtilities
                 ModelBinding<uint16_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(uint16_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(uint16_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -305,7 +305,7 @@ namespace BindingUtilities
                 ModelBinding<int32_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(int32_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(int32_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -320,7 +320,7 @@ namespace BindingUtilities
                 ModelBinding<uint32_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(uint32_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(uint32_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -335,7 +335,7 @@ namespace BindingUtilities
                 ModelBinding<int64_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(int64_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(int64_t) * binding.GetDataBufferSize());
                 }
                 else
                 {
@@ -350,7 +350,7 @@ namespace BindingUtilities
                 ModelBinding<uint64_t> binding(description);
                 if (args.IsGarbageInput())
                 {
-                    memset(binding.GetData(), 0, sizeof(uint64_t) * binding.GetDataBufferSize());
+                    memset(binding.GetData(), 2, sizeof(uint64_t) * binding.GetDataBufferSize());
                 }
                 else
                 {

--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -13,6 +13,36 @@ using namespace winrt::Windows::Graphics::DirectX;
 using namespace winrt::Windows::Graphics::Imaging;
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
+template <TensorKind T> struct TensorKindToType { static_assert(true, "No TensorKind mapped for given type!"); };
+template <> struct TensorKindToType<TensorKind::UInt8> { typedef uint8_t Type; };
+template <> struct TensorKindToType<TensorKind::Int8> { typedef uint8_t Type; };
+template <> struct TensorKindToType<TensorKind::UInt16> { typedef uint16_t Type; };
+template <> struct TensorKindToType<TensorKind::Int16> { typedef int16_t Type; };
+template <> struct TensorKindToType<TensorKind::UInt32> { typedef uint32_t Type; };
+template <> struct TensorKindToType<TensorKind::Int32> { typedef int32_t Type; };
+template <> struct TensorKindToType<TensorKind::UInt64> { typedef uint64_t Type; };
+template <> struct TensorKindToType<TensorKind::Int64> { typedef int64_t Type; };
+template <> struct TensorKindToType<TensorKind::Boolean> { typedef boolean Type; };
+template <> struct TensorKindToType<TensorKind::Double> { typedef double Type; };
+template <> struct TensorKindToType<TensorKind::Float> { typedef float Type; };
+template <> struct TensorKindToType<TensorKind::Float16> { typedef float Type; };
+template <> struct TensorKindToType<TensorKind::String> { typedef winrt::hstring Type; };
+
+template <TensorKind T> struct TensorKindToValue { static_assert(true, "No TensorKind mapped for given type!"); };
+template <> struct TensorKindToValue<TensorKind::UInt8> { typedef TensorUInt8Bit Type; };
+template <> struct TensorKindToValue<TensorKind::Int8> { typedef TensorInt8Bit Type; };
+template <> struct TensorKindToValue<TensorKind::UInt16> { typedef TensorUInt16Bit Type; };
+template <> struct TensorKindToValue<TensorKind::Int16> { typedef TensorInt16Bit Type; };
+template <> struct TensorKindToValue<TensorKind::UInt32> { typedef TensorUInt32Bit Type; };
+template <> struct TensorKindToValue<TensorKind::Int32> { typedef TensorInt32Bit Type; };
+template <> struct TensorKindToValue<TensorKind::UInt64> { typedef TensorUInt64Bit Type; };
+template <> struct TensorKindToValue<TensorKind::Int64> { typedef TensorInt64Bit Type; };
+template <> struct TensorKindToValue<TensorKind::Boolean> { typedef TensorBoolean Type; };
+template <> struct TensorKindToValue<TensorKind::Double> { typedef TensorDouble Type; };
+template <> struct TensorKindToValue<TensorKind::Float> { typedef TensorFloat Type; };
+template <> struct TensorKindToValue<TensorKind::Float16> { typedef TensorFloat16Bit Type; };
+template <> struct TensorKindToValue<TensorKind::String> { typedef TensorString Type; };
+
 namespace BindingUtilities
 {
     static unsigned int seed = 0;
@@ -175,6 +205,41 @@ namespace BindingUtilities
         return elementStrings;
     }
 
+    template <TensorKind T>
+    static ITensor CreateTensor(
+        const CommandLineArgs& args,
+        std::vector<std::string>& tensorStringInput,
+        TensorFeatureDescriptor& tensorDescriptor)
+    {
+        using TensorValue = typename TensorKindToValue<T>::Type;
+        using DataType = typename TensorKindToType<T>::Type;
+
+        if (!args.CsvPath().empty())
+        {
+            ModelBinding<DataType> binding(tensorDescriptor);
+            WriteDataToBinding<DataType>(tensorStringInput, binding);
+            return TensorValue::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+        }
+        else if(args.IsGarbageInput())
+        {
+            auto tensorValue = TensorValue::Create(tensorDescriptor.Shape());
+
+            com_ptr<ITensorNative> spTensorValueNative;
+            tensorValue.as(spTensorValueNative);
+
+            BYTE* actualData;
+            uint32_t actualSizeInBytes;
+            spTensorValueNative->GetBuffer(&actualData, &actualSizeInBytes);
+
+            return tensorValue;
+        }
+        else
+        {
+            //Creating Tensors for Input Images haven't been added yet.
+            throw hresult_not_implemented(L"Creating Tensors for Input Images haven't been implemented yet!");
+        }
+    }
+
     // Binds tensor floats, ints, doubles from CSV data.
     ITensor CreateBindableTensor(const ILearningModelFeatureDescriptor& description, const CommandLineArgs& args)
     {
@@ -188,6 +253,10 @@ namespace BindingUtilities
         }
 
         std::vector<std::string> elementStrings;
+        if (!args.CsvPath().empty())
+        {
+            elementStrings = ParseCSVElementStrings(args.CsvPath());
+        }
         switch (tensorDescriptor.TensorKind())
         {
             case TensorKind::Undefined:
@@ -197,167 +266,57 @@ namespace BindingUtilities
             }
             case TensorKind::Float:
             {
-                ModelBinding<float> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(float) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<float>(elementStrings, binding);
-                }
-                return TensorFloat::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Float>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Float16:
             {
-                ModelBinding<float> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(float) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<float>(elementStrings, binding);
-                }
-                return TensorFloat16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Float16>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Double:
             {
-                ModelBinding<double> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(double) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<double>(elementStrings, binding);
-                }
-                return TensorDouble::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Double>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Int8:
             {
-                ModelBinding<uint8_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(uint8_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<uint8_t>(elementStrings, binding);
-                }
-                return TensorInt8Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Int8>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::UInt8:
             {
-                ModelBinding<uint8_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(uint8_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<uint8_t>(elementStrings, binding);
-                }
-                return TensorUInt8Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::UInt8>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Int16:
             {
-                ModelBinding<int16_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(int16_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<int16_t>(elementStrings, binding);
-                }
-                return TensorInt16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Int16>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::UInt16:
             {
-                ModelBinding<uint16_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(uint16_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<uint16_t>(elementStrings, binding);
-                }
-                return TensorUInt16Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::UInt16>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Int32:
             {
-                ModelBinding<int32_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(int32_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<int32_t>(elementStrings, binding);
-                }
-                return TensorInt32Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Int32>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::UInt32:
             {
-                ModelBinding<uint32_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(uint32_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<uint32_t>(elementStrings, binding);
-                }
-                return TensorUInt32Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::UInt32>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::Int64:
             {
-                ModelBinding<int64_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(int64_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<int64_t>(elementStrings, binding);
-                }
-                return TensorInt64Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::Int64>(args, elementStrings, tensorDescriptor);
             }
             break;
             case TensorKind::UInt64:
             {
-                ModelBinding<uint64_t> binding(description);
-                if (args.IsGarbageInput())
-                {
-                    memset(binding.GetData(), 2, sizeof(uint64_t) * binding.GetDataBufferSize());
-                }
-                else
-                {
-                    elementStrings = ParseCSVElementStrings(args.CsvPath());
-                    WriteDataToBinding<uint64_t>(elementStrings, binding);
-                }
-                return TensorUInt64Bit::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
+                return CreateTensor<TensorKind::UInt64>(args, elementStrings, tensorDescriptor);
             }
             break;
         }

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -283,12 +283,22 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
             m_csvData = m_inputData;
         }
     }
+    CheckForInvalidArguments();
 }
 
-void CommandLineArgs::CheckNextArgument(const std::vector<std::wstring> &args, UINT i) {
+void CommandLineArgs::CheckNextArgument(const std::vector<std::wstring> &args, UINT i)
+{
     if (i + 1 >= args.size() || args[i + 1][0] == L'-') {
         std::wstring msg = L"Invalid parameter for ";
         msg += args[i].c_str();
         throw hresult_invalid_argument(msg.c_str());
+    }
+}
+
+void CommandLineArgs::CheckForInvalidArguments()
+{
+    if (IsGarbageInput() && IsSaveTensor())
+    {
+        throw hresult_invalid_argument(L"Cannot save tensor output if no input data is provided!");
     }
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -149,4 +149,5 @@ private:
     uint32_t m_threadInterval = 0;
 
     void CheckNextArgument(const std::vector<std::wstring> &args, UINT i);
+    void CheckForInvalidArguments();
 };

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -697,7 +697,14 @@ public:
     {
         T* tensor = (T*)buffer;
         int size = uCapacity / sizeof(T);
-        maxValue = *tensor;
+        if (!std::is_same<T, HALF>::value)
+        {
+            maxValue = *tensor;
+        }
+        else
+        {
+            maxValue = XMConvertHalfToFloat(static_cast<HALF>(*tensor));
+        }
         maxIndex = 0;
         for (int i = 0; i < size; i++)
         {


### PR DESCRIPTION
- FP16 tensor tests need to be more lenient because different hardware handles FP16 a little bit differently and the resulting output tensor after evaluation may not be the same between hardware / drivers. For this reason, this change makes the comparison of FP16 tensor output tests to be more lenient.

- There are hardware optimizations for operations when memory is set to 0, such as add or multiply. This PR changes the WinMLRunner to memset the data to just arbitrary data so that the performance captured is more fair. As a result, tensor output tests for garbage data has been removed

- For printing the largest value for FP16 models, there is an edge case where the first index / value has the highest value. However the first value is of type HALF and it is dereferenced without using XMConvertHalfToFloat. As a result, the implicit cast from HALF to float results in a value that isn't correct. This change fixes that.