### PR TITLE
Add clang format

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -1,18 +1,18 @@
-#include <Windows.h>
-#include "Filehelper.h"
 #include "CppUnitTest.h"
-#include <processthreadsapi.h>
-#include <winnt.h>
+#include "Filehelper.h"
 #include <Winbase.h>
+#include <Windows.h>
+#include <algorithm>
+#include <cmath>
+#include <codecvt>
+#include <direct.h>
 #include <filesystem>
 #include <fstream>
-#include <algorithm>
-#include <vector>
-#include <direct.h>
 #include <iomanip>
-#include <codecvt>
-#include <locale> 
-#include <cmath>
+#include <locale>
+#include <processthreadsapi.h>
+#include <vector>
+#include <winnt.h>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 static HRESULT RunProc(LPWSTR commandLine)
@@ -22,8 +22,7 @@ static HRESULT RunProc(LPWSTR commandLine)
     DWORD CreationFlags = 0;
     SI.cb = sizeof(SI);
     Assert::IsTrue(
-        0 != CreateProcess(
-            nullptr, commandLine, nullptr, nullptr, FALSE, CreationFlags, nullptr, nullptr, &SI, &PI));
+        0 != CreateProcess(nullptr, commandLine, nullptr, nullptr, FALSE, CreationFlags, nullptr, nullptr, &SI, &PI));
     Assert::AreEqual(WAIT_OBJECT_0, WaitForSingleObject(PI.hProcess, INFINITE));
     DWORD exitCode;
     Assert::IsTrue(0 != GetExitCodeProcess(PI.hProcess, &exitCode));
@@ -34,678 +33,688 @@ static HRESULT RunProc(LPWSTR commandLine)
 
 namespace WinMLRunnerTest
 {
-    static const std::wstring CURRENT_PATH = FileHelper::GetModulePath();
-    static const std::wstring EXE_PATH = CURRENT_PATH + L"WinMLRunner.exe";
-    static const std::wstring INPUT_FOLDER_PATH = CURRENT_PATH + L"test_folder_input";
-    static const std::wstring OUTPUT_PATH = CURRENT_PATH + L"test_output.csv";
-    static const std::wstring TENSOR_DATA_PATH = CURRENT_PATH + L"\\TestResult";
+static const std::wstring CURRENT_PATH = FileHelper::GetModulePath();
+static const std::wstring EXE_PATH = CURRENT_PATH + L"WinMLRunner.exe";
+static const std::wstring INPUT_FOLDER_PATH = CURRENT_PATH + L"test_folder_input";
+static const std::wstring OUTPUT_PATH = CURRENT_PATH + L"test_output.csv";
+static const std::wstring TENSOR_DATA_PATH = CURRENT_PATH + L"\\TestResult";
 
-    static std::wstring BuildCommand(std::initializer_list<std::wstring>&& arguments)
+static std::wstring BuildCommand(std::initializer_list<std::wstring>&& arguments)
+{
+    std::wstring commandLine;
+
+    for (const std::wstring& argument : arguments)
     {
-        std::wstring commandLine;
+        commandLine += argument + L' ';
+    }
 
-        for (const std::wstring& argument : arguments)
+    return commandLine;
+}
+
+static size_t GetOutputCSVLineCount()
+{
+    std::ifstream fin;
+    fin.open(OUTPUT_PATH);
+    return static_cast<size_t>(std::count(std::istreambuf_iterator<char>(fin), std::istreambuf_iterator<char>(), '\n'));
+}
+
+static void RemoveModelsFromFolder(std::initializer_list<std::string>&& modelList)
+{
+    // make test_models folder
+    std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+    system(mkFolderCommand.c_str());
+
+    // copy models from list to test_folder_input
+    for (auto model : modelList)
+    {
+        std::string copyCommand = "Copy ";
+        copyCommand += model;
+        copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+        system(copyCommand.c_str());
+    }
+}
+
+bool CompareTensorsProvidedEpsilonAndRelativeTolerance(const std::wstring& expectedOutputTensorFile,
+                                                       const std::wstring& actualOutputTensorFile,
+                                                       float relativeTolerance, float epsilon)
+{
+    bool check = false;
+    std::ifstream expectedFileStream;
+    std::ifstream actualFileStream;
+    expectedFileStream.open(expectedOutputTensorFile);
+    actualFileStream.open(actualOutputTensorFile);
+    std::string actualValue;
+    std::string expectedValue;
+    if (expectedFileStream.fail() || actualFileStream.fail())
+    {
+        return false;
+    }
+    bool isFirstRow = true;
+    while (!(expectedFileStream.eof() || actualFileStream.eof()))
+    {
+        std::getline(expectedFileStream, expectedValue, ',');
+        std::getline(expectedFileStream, expectedValue, '\n');
+        std::getline(actualFileStream, actualValue, ',');
+        std::getline(actualFileStream, actualValue, '\n');
+        if (isFirstRow)
         {
-            commandLine += argument + L' ';
+            isFirstRow = false;
+            continue;
         }
-
-        return commandLine;
-    }
-
-    static size_t GetOutputCSVLineCount()
-    {
-        std::ifstream fin;
-        fin.open(OUTPUT_PATH);
-        return static_cast<size_t>(std::count(std::istreambuf_iterator<char>(fin), std::istreambuf_iterator<char>(), '\n'));
-    }
-
-    static void RemoveModelsFromFolder(std::initializer_list<std::string>&& modelList)
-    {
-        //make test_models folder
-        std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-        system(mkFolderCommand.c_str());
-
-        //copy models from list to test_folder_input
-        for (auto model : modelList)
-        {
-            std::string copyCommand = "Copy ";
-            copyCommand += model;
-            copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(copyCommand.c_str());
-        }
-    }
-
-    bool CompareTensorsProvidedEpsilonAndRelativeTolerance(
-        const std::wstring &expectedOutputTensorFile,
-        const std::wstring &actualOutputTensorFile,
-        float relativeTolerance,
-        float epsilon)
-    {
-        bool check = false;
-        std::ifstream expectedFileStream;
-        std::ifstream actualFileStream;
-        expectedFileStream.open(expectedOutputTensorFile);
-        actualFileStream.open(actualOutputTensorFile);
-        std::string actualValue;
-        std::string expectedValue;
-        if (expectedFileStream.fail() || actualFileStream.fail())
+        float actualValueNum = (actualValue == "") ? 0 : std::stof(actualValue);
+        float expectedValueNum = (expectedValue == "") ? 0 : std::stof(expectedValue);
+        if (std::abs(actualValueNum - expectedValueNum) >
+            relativeTolerance * std::abs(expectedValueNum) + epsilon) // Check if the values are too different.
         {
             return false;
         }
-        bool isFirstRow = true;
-        while (!(expectedFileStream.eof() || actualFileStream.eof()))
-        {
-            std::getline(expectedFileStream, expectedValue, ',');
-            std::getline(expectedFileStream, expectedValue, '\n');
-            std::getline(actualFileStream, actualValue, ',');
-            std::getline(actualFileStream, actualValue, '\n');
-            if (isFirstRow)
-            {
-                isFirstRow = false;
-                continue;
-            }
-            float actualValueNum = (actualValue == "") ? 0 : std::stof(actualValue);
-            float expectedValueNum = (expectedValue == "") ? 0 : std::stof(expectedValue);
-            if (std::abs(actualValueNum - expectedValueNum) > relativeTolerance * std::abs(expectedValueNum) + epsilon) //Check if the values are too different.
-            {
-                return false;
-            }
-        }
-        return true;
     }
+    return true;
+}
 
-    bool CompareTensors(const std::wstring &expectedOutputTensorFile, const std::wstring &actualOutputTensorFile)
+bool CompareTensors(const std::wstring& expectedOutputTensorFile, const std::wstring& actualOutputTensorFile)
+{
+    return CompareTensorsProvidedEpsilonAndRelativeTolerance(expectedOutputTensorFile, actualOutputTensorFile, 0.003f,
+                                                             0);
+}
+
+bool CompareTensorsFP16(const std::wstring& expectedOutputTensorFile, const std::wstring& actualOutputTensorFile)
+{
+    return CompareTensorsProvidedEpsilonAndRelativeTolerance(expectedOutputTensorFile, actualOutputTensorFile, 0.06f,
+                                                             0);
+}
+
+TEST_CLASS(GarbageInputTest){ public : TEST_CLASS_INITIALIZE(SetupClass){
+    // Make test_folder_input folder before starting the tests
+    std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+system(mkFolderCommand.c_str());
+
+std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
+
+// Copy models from list to test_folder_input
+for (auto model : models)
+{
+    std::string copyCommand = "Copy ";
+    copyCommand += model;
+    copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+    system(copyCommand.c_str());
+}
+} // namespace WinMLRunnerTest
+
+TEST_CLASS_CLEANUP(CleanupClass)
+{
+    // Delete test_folder_input folder after all tests have been run
+    std::string copyCommand = "rd /s /q ";
+    copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+    system(copyCommand.c_str());
+}
+
+TEST_METHOD_CLEANUP(CleanupMethod)
+{
+    // Remove output.csv after each test
+    // TODO: this will not work if each test runs in parallel. Use different
+    // file path for each test, and clean up at class setup
+    std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
+    try
     {
-        return CompareTensorsProvidedEpsilonAndRelativeTolerance(expectedOutputTensorFile, actualOutputTensorFile, 0.003f, 0);
+        std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
     }
-
-    bool CompareTensorsFP16(const std::wstring &expectedOutputTensorFile, const std::wstring &actualOutputTensorFile)
+    catch (const std::filesystem::filesystem_error&)
     {
-        return CompareTensorsProvidedEpsilonAndRelativeTolerance(expectedOutputTensorFile, actualOutputTensorFile, 0.06f, 0);
     }
-
-    TEST_CLASS(GarbageInputTest)
-    {
-    public:
-        TEST_CLASS_INITIALIZE(SetupClass)
-        {
-            // Make test_folder_input folder before starting the tests
-            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(mkFolderCommand.c_str());
-
-            std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
-
-            // Copy models from list to test_folder_input
-            for (auto model : models)
-            {
-                std::string copyCommand = "Copy ";
-                copyCommand += model;
-                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-                system(copyCommand.c_str());
-            }
-        }
-
-        TEST_CLASS_CLEANUP(CleanupClass)
-        {
-            // Delete test_folder_input folder after all tests have been run
-            std::string copyCommand = "rd /s /q ";
-            copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(copyCommand.c_str());
-        }
-
-        TEST_METHOD_CLEANUP(CleanupMethod)
-        {
-            // Remove output.csv after each test
-            // TODO: this will not work if each test runs in parallel. Use different file path for each test, and clean up at class setup
-            std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
-            try {
-                std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
-            }
-            catch (const std::filesystem::filesystem_error &) {}
-        }
-        TEST_METHOD(GarbageInputCpuAndGpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(3), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputOnlyCpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputOnlyGpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundRGBImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundBGRImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(GarbageInputAllPermutations)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring command = BuildCommand({
-                EXE_PATH,
-                L"-model",
-                modelPath,
-                L"-PerfOutput",
-                OUTPUT_PATH,
-                L"-perf",
-                L"-CPU",
-                L"-GPU",
-                L"-CreateDeviceOnClient",
-                L"-CreateDeviceInWinML",
-                L"-CPUBoundInput",
-                L"-GPUBoundInput",
-                L"-RGB",
-                L"-BGR",
-                L"-tensor"
-            });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(25), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(RunAllModelsInFolderGarbageInput)
-        {
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(5), GetOutputCSVLineCount());
-        }
-
-        TEST_METHOD(RunAllModelsInFolderGarbageInputWithAllPermutations)
-        {
-            const std::wstring command = BuildCommand({
-                EXE_PATH,
-                L"-folder",
-                INPUT_FOLDER_PATH,
-                L"-PerfOutput",
-                OUTPUT_PATH,
-                L"-perf",
-                L"-CPU",
-                L"-GPU",
-                L"-CreateDeviceOnClient",
-                L"-CreateDeviceInWinML",
-                L"-CPUBoundInput",
-                L"-GPUBoundInput",
-                L"-RGB",
-                L"-BGR",
-                L"-tensor"
-                });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            // We need to expect one more line because of the header
-            Assert::AreEqual(static_cast<size_t>(49), GetOutputCSVLineCount());
-        }
-    };
-
-    TEST_CLASS(ImageInputTest)
-    {
-    public:
-        TEST_METHOD_CLEANUP(CleanupMethod)
-        {
-            // Remove output.csv after each test
-            // TODO: this will not work if each test runs in parallel. Use different file path for each test, and clean up at class setup
-            std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
-            try {
-                std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
-            }
-            catch (const std::filesystem::filesystem_error &) {}
-        }
-        TEST_METHOD(ProvidedImageInputCpuAndGpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath });
-        }
-
-        TEST_METHOD(ProvidedImageInputOnlyCpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-        }
-
-        TEST_METHOD(ProvidedImageInputOnlyGpu)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-        }
-
-        TEST_METHOD(AutoScaleImage)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish_112.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-autoScale", L"Cubic" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
-        }
-        TEST_METHOD(ProvidedImageInputOnlyGpuSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
-                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedImageInputOnlyCpuSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
-                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedImageInputOnlyGpuSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
-                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedImageInputOnlyCpuSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.png";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
-                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
-    };
-
-    TEST_CLASS(CsvInputTest)
-    {
-    public:
-
-        TEST_METHOD_CLEANUP(CleanupMethod)
-        {
-            // Remove output.csv after each test
-            // TODO: this will not work if each test runs in parallel. Use different file path for each test, and clean up at class setup
-            std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
-            try {
-                std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
-            }
-            catch (const std::filesystem::filesystem_error &) {}
-        }
-        TEST_METHOD(ProvidedCSVInput)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"kitten_224.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-        }
-        TEST_METHOD(ProvidedCSVBadBinding)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"horizontal-crop.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath });
-            Assert::AreEqual(HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER), RunProc((wchar_t *)command.c_str()));
-        }
-        TEST_METHOD(ProvidedCSVInputGPUSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath, L"-SaveTensorData",
-                L"First", TENSOR_DATA_PATH, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedCSVInputCPUSaveTensor)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath, L"-SaveTensorData",
-                L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedCSVInputGPUSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath, L"-SaveTensorData",
-                L"First", TENSOR_DATA_PATH, L"-GPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_GPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
-        }
-        TEST_METHOD(ProvidedCSVInputCPUSaveTensorFp16)
-        {
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
-            const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath, L"-SaveTensorData",
-                L"First", TENSOR_DATA_PATH, L"-CPU" });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-            Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_CPU.csv", TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
-        }
-    };
-
-    TEST_CLASS(ConcurrencyTest)
-    {
-    public:
-        TEST_CLASS_INITIALIZE(SetupClass)
-        {
-            // Make test_folder_input folder before starting the tests
-            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(mkFolderCommand.c_str());
-
-            std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
-
-            // Copy models from list to test_folder_input
-            for (auto model : models)
-            {
-                std::string copyCommand = "Copy ";
-                copyCommand += model;
-                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-                system(copyCommand.c_str());
-            }
-        }
-
-        TEST_METHOD(RunFolder)
-        {
-            const std::wstring command = BuildCommand({
-                EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-ConcurrentLoad", L"-NumThreads", L"5"
-            });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-        }
-    };
-
-    TEST_CLASS(OtherTests)
-    {
-    public:
-        TEST_METHOD(LoadModelFailModelNotFound)
-        {
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", L"invalid_model_name" });
-            Assert::AreEqual(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), RunProc((wchar_t *)command.c_str()));
-        }
-
-        TEST_METHOD(TestPrintUsage)
-        {
-            const std::wstring command = BuildCommand({ EXE_PATH });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-        }
-        
-        /* Commenting out test until WinMLRunnerDLL.dll is properly written and ABI friendly
-        TEST_METHOD(TestWinMLRunnerDllLinking)
-        {
-            // Before running rest of test, make sure that this file doesn't exist or 
-            // else renaming WinMLRunnerDLL.dll won't execute properly.
-            remove("WinMLRunnerDLL_renamed");
-
-            //Run DLL Linked Executable and check if success
-            const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
-            const std::wstring dllPath = CURRENT_PATH + L"WinMLRunnerDLL.dll";
-            const std::wstring command = BuildCommand({ L"WinMLRunner_Link_DLL.exe",  L"-model", modelPath });
-            Assert::AreEqual(S_OK, RunProc((wchar_t *)command.c_str()));
-
-            //Rename WinMLRunnerDLL and then run DLL Linked Executable and check if failed
-            rename("WinMLRunnerDLL.dll", "WinMLRunnerDLL_renamed");
-            Assert::AreEqual(static_cast<HRESULT>(STATUS_DLL_NOT_FOUND), RunProc((wchar_t *)command.c_str()));
-
-            //rename back to original naming
-            rename("WinMLRunnerDLL_renamed", "WinMLRunnerDLL.dll");
-        }
-        */
-    };
+}
+TEST_METHOD(GarbageInputCpuAndGpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(3), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputOnlyCpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputOnlyGpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceCpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceCpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuClientDeviceGpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputCpuWinMLDeviceGpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceCpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceCpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-CPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundRGBImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-RGB", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundBGRImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-BGR", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuClientDeviceGpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceOnClient" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputGpuWinMLDeviceGpuBoundTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-GPU", L"-GPUBoundInput", L"-tensor", L"-CreateDeviceInWinML" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(GarbageInputAllPermutations)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-PerfOutput", OUTPUT_PATH, L"-perf",
+                                                L"-CPU", L"-GPU", L"-CreateDeviceOnClient", L"-CreateDeviceInWinML",
+                                                L"-CPUBoundInput", L"-GPUBoundInput", L"-RGB", L"-BGR", L"-tensor" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(25), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(RunAllModelsInFolderGarbageInput)
+{
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-PerfOutput", OUTPUT_PATH, L"-perf" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(5), GetOutputCSVLineCount());
+}
+
+TEST_METHOD(RunAllModelsInFolderGarbageInputWithAllPermutations)
+{
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-PerfOutput", OUTPUT_PATH, L"-perf", L"-CPU", L"-GPU",
+                       L"-CreateDeviceOnClient", L"-CreateDeviceInWinML", L"-CPUBoundInput", L"-GPUBoundInput", L"-RGB",
+                       L"-BGR", L"-tensor" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+    // We need to expect one more line because of the header
+    Assert::AreEqual(static_cast<size_t>(49), GetOutputCSVLineCount());
+}
+}
+;
+
+TEST_CLASS(ImageInputTest){ public : TEST_METHOD_CLEANUP(CleanupMethod){
+    // Remove output.csv after each test
+    // TODO: this will not work if each test runs in parallel. Use different
+    // file path for each test, and clean up at class setup
+    std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
+try
+{
+    std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
+}
+catch (const std::filesystem::filesystem_error&)
+{
+}
+}
+TEST_METHOD(ProvidedImageInputCpuAndGpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath });
+}
+
+TEST_METHOD(ProvidedImageInputOnlyCpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+
+TEST_METHOD(ProvidedImageInputOnlyGpu)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+
+TEST_METHOD(AutoScaleImage)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish_112.png";
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath, L"-autoScale", L"Cubic" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+TEST_METHOD(ProvidedImageInputOnlyGpuSaveTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_GPU.csv",
+                                          TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedImageInputOnlyCpuSaveTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_CPU.csv",
+                                          TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedImageInputOnlyGpuSaveTensorFp16)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_GPU.csv",
+                                              TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedImageInputOnlyCpuSaveTensorFp16)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.png";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model ", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_CPU.csv",
+                                              TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
+}
+}
+;
+
+TEST_CLASS(CsvInputTest){
+    public :
+
+        TEST_METHOD_CLEANUP(CleanupMethod){ // Remove output.csv after each test
+                                            // TODO: this will not work if each test runs in parallel. Use
+                                            // different file path for each test, and clean up at class setup
+                                            std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
+try
+{
+    std::filesystem::remove_all(std::string(TENSOR_DATA_PATH.begin(), TENSOR_DATA_PATH.end()).c_str());
+}
+catch (const std::filesystem::filesystem_error&)
+{
+}
+}
+TEST_METHOD(ProvidedCSVInput)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"kitten_224.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+TEST_METHOD(ProvidedCSVBadBinding)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"horizontal-crop.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath });
+    Assert::AreEqual(HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER), RunProc((wchar_t*)command.c_str()));
+}
+TEST_METHOD(ProvidedCSVInputGPUSaveTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_GPU.csv",
+                                          TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedCSVInputCPUSaveTensor)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensors(L"OutputTensorData\\Squeezenet_fish_input_CPU.csv",
+                                          TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedCSVInputGPUSaveTensorFp16)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-GPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_GPU.csv",
+                                              TENSOR_DATA_PATH + L"\\softmaxout_1GpuIteration1.csv"));
+}
+TEST_METHOD(ProvidedCSVInputCPUSaveTensorFp16)
+{
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet_fp16.onnx";
+    const std::wstring inputPath = CURRENT_PATH + L"fish.csv";
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", modelPath, L"-input", inputPath,
+                                                L"-SaveTensorData", L"First", TENSOR_DATA_PATH, L"-CPU" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+    Assert::AreEqual(true, CompareTensorsFP16(L"OutputTensorData\\Squeezenet_fp16_fish_input_CPU.csv",
+                                              TENSOR_DATA_PATH + L"\\softmaxout_1CpuIteration1.csv"));
+}
+}
+;
+
+TEST_CLASS(ConcurrencyTest){ public : TEST_CLASS_INITIALIZE(SetupClass){
+    // Make test_folder_input folder before starting the tests
+    std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+system(mkFolderCommand.c_str());
+
+std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
+
+// Copy models from list to test_folder_input
+for (auto model : models)
+{
+    std::string copyCommand = "Copy ";
+    copyCommand += model;
+    copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+    system(copyCommand.c_str());
+}
+}
+
+TEST_METHOD(RunFolder)
+{
+    const std::wstring command =
+        BuildCommand({ EXE_PATH, L"-folder", INPUT_FOLDER_PATH, L"-ConcurrentLoad", L"-NumThreads", L"5" });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+}
+;
+
+TEST_CLASS(OtherTests){ public : TEST_METHOD(LoadModelFailModelNotFound){
+    const std::wstring command = BuildCommand({ EXE_PATH, L"-model", L"invalid_model_name" });
+Assert::AreEqual(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), RunProc((wchar_t*)command.c_str()));
+}
+
+TEST_METHOD(TestPrintUsage)
+{
+    const std::wstring command = BuildCommand({ EXE_PATH });
+    Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+}
+
+/* Commenting out test until WinMLRunnerDLL.dll is properly written and ABI
+friendly TEST_METHOD(TestWinMLRunnerDllLinking)
+{
+    // Before running rest of test, make sure that this file doesn't exist or
+    // else renaming WinMLRunnerDLL.dll won't execute properly.
+    remove("WinMLRunnerDLL_renamed");
+
+    //Run DLL Linked Executable and check if success
+    const std::wstring modelPath = CURRENT_PATH + L"SqueezeNet.onnx";
+    const std::wstring dllPath = CURRENT_PATH + L"WinMLRunnerDLL.dll";
+    const std::wstring command = BuildCommand({ L"WinMLRunner_Link_DLL.exe",
+L"-model", modelPath }); Assert::AreEqual(S_OK, RunProc((wchar_t
+*)command.c_str()));
+
+    //Rename WinMLRunnerDLL and then run DLL Linked Executable and check if
+failed rename("WinMLRunnerDLL.dll", "WinMLRunnerDLL_renamed");
+    Assert::AreEqual(static_cast<HRESULT>(STATUS_DLL_NOT_FOUND),
+RunProc((wchar_t *)command.c_str()));
+
+    //rename back to original naming
+    rename("WinMLRunnerDLL_renamed", "WinMLRunnerDLL.dll");
+}
+*/
+}
+;
 }

--- a/Tools/WinMLRunner/.clang-format
+++ b/Tools/WinMLRunner/.clang-format
@@ -1,0 +1,11 @@
+Language:        Cpp
+BasedOnStyle:  LLVM
+
+AccessModifierOffset: -4
+BreakBeforeBraces: Allman # break before braces
+ColumnLimit: 120
+IndentWidth: 4
+PointerAlignment: Left # Type* A as opposed to Type *A
+Cpp11BracedListStyle: false # space before/after braces
+NamespaceIndentation: All
+IndentCaseLabels: true

--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -1,9 +1,9 @@
 #pragma once
-#include <random>
-#include <time.h>
 #include "Common.h"
 #include "ModelBinding.h"
 #include "Windows.AI.Machinelearning.Native.h"
+#include <random>
+#include <time.h>
 
 using namespace winrt::Windows::Media;
 using namespace winrt::Windows::Storage;
@@ -80,10 +80,12 @@ namespace BindingUtilities
         IBuffer buffer = dataWriter.DetachBuffer();
 
         // Create the software bitmap
-        return SoftwareBitmap::CreateCopyFromBuffer(buffer, TypeHelper::GetBitmapPixelFormat(inputDataType), static_cast<int32_t>(width), static_cast<int32_t>(height));
+        return SoftwareBitmap::CreateCopyFromBuffer(buffer, TypeHelper::GetBitmapPixelFormat(inputDataType),
+                                                    static_cast<int32_t>(width), static_cast<int32_t>(height));
     }
 
-    SoftwareBitmap LoadImageFile(const TensorFeatureDescriptor& imageDescriptor, InputDataType inputDataType, const hstring& filePath, const CommandLineArgs& args, uint32_t iterationNum)
+    SoftwareBitmap LoadImageFile(const TensorFeatureDescriptor& imageDescriptor, InputDataType inputDataType,
+                                 const hstring& filePath, const CommandLineArgs& args, uint32_t iterationNum)
     {
         assert(inputDataType != InputDataType::Tensor);
 
@@ -103,12 +105,11 @@ namespace BindingUtilities
             BitmapDecoder decoder = BitmapDecoder::CreateAsync(stream).get();
 
             // If input dimensions are different from tensor input, then scale / crop while reading
-            if (args.IsAutoScale() &&
-                 ( decoder.PixelHeight() != height ||
-                   decoder.PixelWidth() != width))
+            if (args.IsAutoScale() && (decoder.PixelHeight() != height || decoder.PixelWidth() != width))
             {
                 if (!args.TerseOutput() || iterationNum == 0)
-                    std::cout << std::endl << "Binding Utilities: AutoScaling input image to match model input dimensions...";
+                    std::cout << std::endl
+                              << "Binding Utilities: AutoScaling input image to match model input dimensions...";
 
                 // Create a transform object with default parameters (no transform)
                 auto transform = BitmapTransform();
@@ -117,34 +118,43 @@ namespace BindingUtilities
                 transform.InterpolationMode(args.AutoScaleInterpMode());
 
                 // get the bitmap
-                return decoder.GetSoftwareBitmapAsync(TypeHelper::GetBitmapPixelFormat(inputDataType),
-                    BitmapAlphaMode::Ignore,
-                    transform,
-                    ExifOrientationMode::RespectExifOrientation,
-                    ColorManagementMode::DoNotColorManage).get();
+                return decoder
+                    .GetSoftwareBitmapAsync(TypeHelper::GetBitmapPixelFormat(inputDataType), BitmapAlphaMode::Ignore,
+                                            transform, ExifOrientationMode::RespectExifOrientation,
+                                            ColorManagementMode::DoNotColorManage)
+                    .get();
             }
             else
             {
                 // get the bitmap
-                return decoder.GetSoftwareBitmapAsync(TypeHelper::GetBitmapPixelFormat(inputDataType), BitmapAlphaMode::Ignore).get();
+                return decoder
+                    .GetSoftwareBitmapAsync(TypeHelper::GetBitmapPixelFormat(inputDataType), BitmapAlphaMode::Ignore)
+                    .get();
             }
         }
         catch (...)
         {
-            std::cout << "BindingUtilities: could not open image file, make sure you are using fully qualified paths." << std::endl;
+            std::cout << "BindingUtilities: could not open image file, make sure you are using fully qualified paths."
+                      << std::endl;
             return nullptr;
         }
     }
 
-    VideoFrame CreateVideoFrame(const SoftwareBitmap& softwareBitmap, InputBindingType inputBindingType, InputDataType inputDataType, const IDirect3DDevice winrtDevice)
+    VideoFrame CreateVideoFrame(const SoftwareBitmap& softwareBitmap, InputBindingType inputBindingType,
+                                InputDataType inputDataType, const IDirect3DDevice winrtDevice)
     {
         VideoFrame inputImage = VideoFrame::CreateWithSoftwareBitmap(softwareBitmap);
 
         if (inputBindingType == InputBindingType::GPU)
         {
-            VideoFrame gpuImage = winrtDevice
-                ? VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType), softwareBitmap.PixelWidth(), softwareBitmap.PixelHeight(), winrtDevice)
-                : VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType), softwareBitmap.PixelWidth(), softwareBitmap.PixelHeight());
+            VideoFrame gpuImage =
+                winrtDevice
+                    ? VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType),
+                                                                  softwareBitmap.PixelWidth(),
+                                                                  softwareBitmap.PixelHeight(), winrtDevice)
+                    : VideoFrame::CreateAsDirect3D11SurfaceBacked(TypeHelper::GetDirectXPixelFormat(inputDataType),
+                                                                  softwareBitmap.PixelWidth(),
+                                                                  softwareBitmap.PixelHeight());
 
             inputImage.CopyToAsync(gpuImage).get();
 
@@ -182,7 +192,7 @@ namespace BindingUtilities
             throw hresult_invalid_argument(L"CSV Input is size/shape is different from what model expects");
         }
         T* data = binding.GetData();
-        for (const auto &elementString : elementStrings)
+        for (const auto& elementString : elementStrings)
         {
             T value;
             std::stringstream(elementString) >> value;
@@ -206,10 +216,8 @@ namespace BindingUtilities
     }
 
     template <TensorKind T>
-    static ITensor CreateTensor(
-        const CommandLineArgs& args,
-        std::vector<std::string>& tensorStringInput,
-        TensorFeatureDescriptor& tensorDescriptor)
+    static ITensor CreateTensor(const CommandLineArgs& args, std::vector<std::string>& tensorStringInput,
+                                TensorFeatureDescriptor& tensorDescriptor)
     {
         using TensorValue = typename TensorKindToValue<T>::Type;
         using DataType = typename TensorKindToType<T>::Type;
@@ -220,7 +228,7 @@ namespace BindingUtilities
             WriteDataToBinding<DataType>(tensorStringInput, binding);
             return TensorValue::CreateFromArray(binding.GetShapeBuffer(), binding.GetDataBuffer());
         }
-        else if(args.IsGarbageInput())
+        else if (args.IsGarbageInput())
         {
             auto tensorValue = TensorValue::Create(tensorDescriptor.Shape());
 
@@ -235,7 +243,7 @@ namespace BindingUtilities
         }
         else
         {
-            //Creating Tensors for Input Images haven't been added yet.
+            // Creating Tensors for Input Images haven't been added yet.
             throw hresult_not_implemented(L"Creating Tensors for Input Images haven't been implemented yet!");
         }
     }
@@ -325,16 +333,10 @@ namespace BindingUtilities
         throw hresult_not_implemented();
     }
 
-    ImageFeatureValue CreateBindableImage(
-        const ILearningModelFeatureDescriptor&
-        featureDescriptor,
-        const std::wstring& imagePath,
-        InputBindingType inputBindingType,
-        InputDataType inputDataType,
-        const IDirect3DDevice winrtDevice,
-        const CommandLineArgs& args,
-        uint32_t iterationNum
-    )
+    ImageFeatureValue CreateBindableImage(const ILearningModelFeatureDescriptor& featureDescriptor,
+                                          const std::wstring& imagePath, InputBindingType inputBindingType,
+                                          InputDataType inputDataType, const IDirect3DDevice winrtDevice,
+                                          const CommandLineArgs& args, uint32_t iterationNum)
     {
         auto imageDescriptor = featureDescriptor.try_as<TensorFeatureDescriptor>();
 
@@ -344,16 +346,16 @@ namespace BindingUtilities
             throw;
         }
 
-        auto softwareBitmap = imagePath.empty()
-            ? GenerateGarbageImage(imageDescriptor, inputDataType)
-            : LoadImageFile(imageDescriptor, inputDataType, imagePath.c_str(), args, iterationNum);
+        auto softwareBitmap =
+            imagePath.empty() ? GenerateGarbageImage(imageDescriptor, inputDataType)
+                              : LoadImageFile(imageDescriptor, inputDataType, imagePath.c_str(), args, iterationNum);
 
         auto videoFrame = CreateVideoFrame(softwareBitmap, inputBindingType, inputDataType, winrtDevice);
 
         return ImageFeatureValue::CreateFromVideoFrame(videoFrame);
     }
 
-    template<typename K, typename V>
+    template <typename K, typename V>
     void OutputSequenceBinding(IMapView<hstring, winrt::Windows::Foundation::IInspectable> results, hstring name)
     {
         auto map = results.Lookup(name).as<IVectorView<IMap<K, V>>>().GetAt(0);
@@ -375,11 +377,9 @@ namespace BindingUtilities
         std::cout << " " << maxKey << " " << maxVal << std::endl;
     }
 
-    void PrintOrSaveEvaluationResults(const LearningModel& model,
-                                      const CommandLineArgs& args,
+    void PrintOrSaveEvaluationResults(const LearningModel& model, const CommandLineArgs& args,
                                       const IMapView<hstring, winrt::Windows::Foundation::IInspectable>& results,
-                                      OutputHelper& output,
-                                      int iterationNum)
+                                      OutputHelper& output, int iterationNum)
     {
         for (auto&& desc : model.OutputFeatures())
         {
@@ -405,59 +405,63 @@ namespace BindingUtilities
                 if (args.IsSaveTensor())
                 {
                     fout.open(output.getCsvFileNamePerIterationResult(), std::ios_base::app);
-                    fout << "Index" << "," << "Value" << std::endl;
+                    fout << "Index"
+                         << ","
+                         << "Value" << std::endl;
                 }
                 TensorFeatureDescriptor tensorDescriptor = desc.as<TensorFeatureDescriptor>();
                 TensorKind tensorKind = tensorDescriptor.TensorKind();
                 switch (tensorKind)
                 {
-                case TensorKind::String:
-                {
-                    if (!args.IsGarbageInput())
+                    case TensorKind::String:
                     {
-                        auto resultVector = results.Lookup(desc.Name()).as<TensorString>().GetAsVectorView();
-                        auto output = resultVector.GetAt(0).data();
-                        std::wcout << " Result: " << output << std::endl;
+                        if (!args.IsGarbageInput())
+                        {
+                            auto resultVector = results.Lookup(desc.Name()).as<TensorString>().GetAsVectorView();
+                            auto output = resultVector.GetAt(0).data();
+                            std::wcout << " Result: " << output << std::endl;
+                        }
                     }
-                }
-                break;
-                case TensorKind::Float16:
-                {
-                    output.ProcessTensorResult<HALF>(args, tensor, uCapacity, maxValue, maxIndex, fout);
-                }
-                break;
-                case TensorKind::Float:
-                {
-                    output.ProcessTensorResult<float>(args, tensor, uCapacity, maxValue, maxIndex, fout);
-                }
-                break;
-                case TensorKind::Int64:
-                {
-                    auto resultVector = results.Lookup(desc.Name()).as<TensorInt64Bit>().GetAsVectorView();
-                    if (!args.IsGarbageInput())
+                    break;
+                    case TensorKind::Float16:
                     {
-                        auto output = resultVector.GetAt(0);
-                        std::wcout << " Result: " << output << std::endl;
+                        output.ProcessTensorResult<HALF>(args, tensor, uCapacity, maxValue, maxIndex, fout);
                     }
-                }
-                break;
-                default:
-                {
-                    std::cout << "BindingUtilities: output type not implemented.";
-                }
-                break;
+                    break;
+                    case TensorKind::Float:
+                    {
+                        output.ProcessTensorResult<float>(args, tensor, uCapacity, maxValue, maxIndex, fout);
+                    }
+                    break;
+                    case TensorKind::Int64:
+                    {
+                        auto resultVector = results.Lookup(desc.Name()).as<TensorInt64Bit>().GetAsVectorView();
+                        if (!args.IsGarbageInput())
+                        {
+                            auto output = resultVector.GetAt(0);
+                            std::wcout << " Result: " << output << std::endl;
+                        }
+                    }
+                    break;
+                    default:
+                    {
+                        std::cout << "BindingUtilities: output type not implemented.";
+                    }
+                    break;
                 }
                 if (args.IsSaveTensor())
                 {
                     fout.close();
-                    std::string iterationResult = "Index: " + std::to_string(maxIndex) + "; Value: " + std::to_string(maxValue);
+                    std::string iterationResult =
+                        "Index: " + std::to_string(maxIndex) + "; Value: " + std::to_string(maxValue);
                     output.SaveResult(iterationNum, iterationResult, static_cast<int>(hash_data(tensor, uCapacity)));
                 }
                 if (!args.IsGarbageInput() && iterationNum == 0)
                 {
                     std::cout << "Outputting results.. " << std::endl;
                     std::cout << "Feature Name: " << name << std::endl;
-                    std::wcout << " resultVector[" << maxIndex << "] has the maximal value of " << maxValue << std::endl;
+                    std::wcout << " resultVector[" << maxIndex << "] has the maximal value of " << maxValue
+                               << std::endl;
                 }
             }
             else if (desc.Kind() == LearningModelFeatureKind::Sequence)
@@ -469,18 +473,18 @@ namespace BindingUtilities
                 auto tensorKind = valueKind.as<TensorFeatureDescriptor>().TensorKind();
                 switch (keyKind)
                 {
-                case TensorKind::Int64:
-                {
-                    OutputSequenceBinding<int64_t, float>(results, desc.Name());
-                }
-                break;
-                case TensorKind::Float:
-                {
-                    OutputSequenceBinding<float, float>(results, desc.Name());
-                }
-                break;
+                    case TensorKind::Int64:
+                    {
+                        OutputSequenceBinding<int64_t, float>(results, desc.Name());
+                    }
+                    break;
+                    case TensorKind::Float:
+                    {
+                        OutputSequenceBinding<float, float>(results, desc.Name());
+                    }
+                    break;
                 }
             }
         }
     }
- };
+}; // namespace BindingUtilities

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -1,49 +1,76 @@
-#include <Windows.h>
-#include <string>
-#include <iostream>
 #include "CommandLineArgs.h"
+#include <Windows.h>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
+#include <string>
 
 using namespace Windows::AI::MachineLearning;
 
-void CommandLineArgs::PrintUsage() {
+void CommandLineArgs::PrintUsage()
+{
     std::cout << "WinML Runner" << std::endl;
     std::cout << " ---------------------------------------------------------------" << std::endl;
     std::cout << "WinmlRunner.exe <-model | -folder> <fully qualified path> [options]" << std::endl;
     std::cout << std::endl;
     std::cout << "options: " << std::endl;
-    std::cout << "  -version: prints the version information for this build of WinMLRunner.exe" << std::endl;
+    std::cout << "  -version: prints the version information for this build of "
+                 "WinMLRunner.exe"
+              << std::endl;
     std::cout << "  -CPU : run model on default CPU" << std::endl;
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
-    std::cout << "  -CreateDeviceOnClient : create the device on the client and pass it to WinML" << std::endl;
+    std::cout << "  -CreateDeviceOnClient : create the device on the client "
+                 "and pass it to WinML"
+              << std::endl;
     std::cout << "  -CreateDeviceInWinML : create the device inside WinML" << std::endl;
     std::cout << "  -CPUBoundInput : bind the input to the CPU" << std::endl;
     std::cout << "  -GPUBoundInput : bind the input to the GPU" << std::endl;
     std::cout << "  -RGB : load the input as an RGB image" << std::endl;
     std::cout << "  -BGR : load the input as a BGR image" << std::endl;
     std::cout << "  -Tensor : load the input as a tensor" << std::endl;
-    std::cout << "  -Perf [all]: capture performance measurements such as timing and memory usage. Specifying \"all\" will output all measurements" << std::endl;
+    std::cout << "  -Perf [all]: capture performance measurements such as timing and "
+                 "memory usage. Specifying \"all\" will output all measurements"
+              << std::endl;
     std::cout << "  -Iterations : # times perf measurements will be run/averaged" << std::endl;
     std::cout << "  -Input <fully qualified path>: binds image or CSV to model" << std::endl;
-    std::cout << "  -PerfOutput [<fully qualified path>]: csv file to write the perf results to" << std::endl;
-    std::cout << "  -SavePerIterationPerf : save per iteration performance results to csv file" << std::endl;
-    std::cout << "  -SaveTensorData <saveMode folderPath>: saveMode: save first iteration or all iteration output tensor results to csv file [First, All]" << std::endl;
-    std::cout << "                                         folderPath: Optional folder path can be specified to hold tensor data. It will be created if folder doesn't exist." << std::endl;
-    std::cout << "  -DebugEvaluate: Print evaluation debug output to debug console if debugger is present." << std::endl;
+    std::cout << "  -PerfOutput [<fully qualified path>]: csv file to write "
+                 "the perf results to"
+              << std::endl;
+    std::cout << "  -SavePerIterationPerf : save per iteration performance "
+                 "results to csv file"
+              << std::endl;
+    std::cout << "  -SaveTensorData <saveMode folderPath>: saveMode: save "
+                 "first iteration or all iteration output tensor results to "
+                 "csv file [First, All]"
+              << std::endl;
+    std::cout << "                                         folderPath: "
+                 "Optional folder path can be specified to hold tensor data. "
+                 "It will be created if folder doesn't exist."
+              << std::endl;
+    std::cout << "  -DebugEvaluate: Print evaluation debug output to debug "
+                 "console if debugger is present."
+              << std::endl;
     std::cout << "  -Terse: Terse Mode (suppresses repetitive console output)" << std::endl;
-    std::cout << "  -AutoScale <interpolationMode>: Enable image autoscaling and set the interpolation mode [Nearest, Linear, Cubic, Fant]" << std::endl;
+    std::cout << "  -AutoScale <interpolationMode>: Enable image autoscaling "
+                 "and set the interpolation mode [Nearest, Linear, Cubic, Fant]"
+              << std::endl;
     std::cout << std::endl;
     std::cout << "Concurrency Options:" << std::endl;
     std::cout << "  -ConcurrentLoad: load models concurrently" << std::endl;
-    std::cout << "  -NumThreads <number>: number of threads to load a model. By default this will be the number of model files to be executed" << std::endl;
-    std::cout << "  -ThreadInterval <milliseconds>: interval time between two thread creations in milliseconds" << std::endl;
+    std::cout << "  -NumThreads <number>: number of threads to load a model. By "
+                 "default this will be the number of model files to be executed"
+              << std::endl;
+    std::cout << "  -ThreadInterval <milliseconds>: interval time between two "
+                 "thread creations in milliseconds"
+              << std::endl;
 }
 
-void CheckAPICall(int return_value) {
-    if (return_value == 0) {
+void CheckAPICall(int return_value)
+{
+    if (return_value == 0)
+    {
         auto code = GetLastError();
         std::wstring msg = L"failed to get the version of this file with error code: ";
         msg += std::to_wstring(code);
@@ -51,7 +78,7 @@ void CheckAPICall(int return_value) {
     }
 }
 
-CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
+CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
 {
     for (UINT i = 0; i < args.size(); i++)
     {
@@ -138,7 +165,8 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
         {
             if (!IsDebuggerPresent())
             {
-                throw hresult_invalid_argument(L"-DebugEvaluate flag should only be used when WinMLRunner is under a user-mode debugger!");
+                throw hresult_invalid_argument(L"-DebugEvaluate flag should only be used when WinMLRunner "
+                                               L"is under a user-mode debugger!");
             }
             ToggleEvaluationDebugOutput(true);
         }
@@ -195,11 +223,13 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
             }
             try
             {
-                // This is to check for second optional value for -SaveTensorData to specify path
+                // This is to check for second optional value for
+                // -SaveTensorData to specify path
                 CheckNextArgument(args, i);
                 SetTensorOutputPath(args[++i].c_str());
             }
-            catch (...) {
+            catch (...)
+            {
                 // set to default path
                 auto time = std::time(nullptr);
                 struct tm localTime;
@@ -215,23 +245,23 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
             auto ret = GetModuleFileName(NULL, szExeFileName, MAX_PATH);
             CheckAPICall(ret);
             uint32_t versionInfoSize = GetFileVersionInfoSize(szExeFileName, 0);
-            wchar_t *pVersionData = new wchar_t[versionInfoSize / sizeof(wchar_t)];
+            wchar_t* pVersionData = new wchar_t[versionInfoSize / sizeof(wchar_t)];
             CheckAPICall(GetFileVersionInfo(szExeFileName, 0, versionInfoSize, pVersionData));
 
-            wchar_t *pOriginalFilename;
+            wchar_t* pOriginalFilename;
             uint32_t originalFilenameSize;
             CheckAPICall(VerQueryValue(pVersionData, L"\\StringFileInfo\\040904b0\\OriginalFilename",
-                (void**)&pOriginalFilename, &originalFilenameSize));
+                                       (void**)&pOriginalFilename, &originalFilenameSize));
 
-            wchar_t *pProductVersion;
+            wchar_t* pProductVersion;
             uint32_t productVersionSize;
             CheckAPICall(VerQueryValue(pVersionData, L"\\StringFileInfo\\040904b0\\ProductVersion",
-                (void**)&pProductVersion, &productVersionSize));
+                                       (void**)&pProductVersion, &productVersionSize));
 
-            wchar_t *pFileVersion;
+            wchar_t* pFileVersion;
             uint32_t fileVersionSize;
-            CheckAPICall(VerQueryValue(pVersionData, L"\\StringFileInfo\\040904b0\\FileVersion",
-                (void**)&pFileVersion, &fileVersionSize));
+            CheckAPICall(VerQueryValue(pVersionData, L"\\StringFileInfo\\040904b0\\FileVersion", (void**)&pFileVersion,
+                                       &fileVersionSize));
 
             std::wcout << pOriginalFilename << std::endl;
             std::wcout << L"Version: " << pFileVersion << "." << pProductVersion << std::endl;
@@ -290,9 +320,10 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring> &args)
     CheckForInvalidArguments();
 }
 
-void CommandLineArgs::CheckNextArgument(const std::vector<std::wstring> &args, UINT i)
+void CommandLineArgs::CheckNextArgument(const std::vector<std::wstring>& args, UINT i)
 {
-    if (i + 1 >= args.size() || args[i + 1][0] == L'-') {
+    if (i + 1 >= args.size() || args[i + 1][0] == L'-')
+    {
         std::wstring msg = L"Invalid parameter for ";
         msg += args[i].c_str();
         throw hresult_invalid_argument(msg.c_str());

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -4,8 +4,8 @@
 class CommandLineArgs
 {
 public:
-    CommandLineArgs() {};
-    CommandLineArgs(const std::vector<std::wstring>& args);
+    CommandLineArgs(){};
+    CommandLineArgs(const std::vector<std::wstring> &args);
     void PrintUsage();
     bool IsConcurrentLoad() const { return m_concurrentLoad; }
     bool IsUsingGPUHighPerformance() const { return m_useGPUHighPerformance; }
@@ -23,17 +23,18 @@ public:
     bool IsSaveTensor() const { return m_saveTensor; }
 
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
-   
-    const std::wstring& ImagePath() const { return m_imagePath; }
-    const std::wstring& CsvPath() const { return m_csvData; }
-    const std::wstring& OutputPath() const { return m_perfOutputPath; }
-    const std::wstring& FolderPath() const { return m_modelFolderPath; }
-    const std::wstring& ModelPath() const { return m_modelPath; }
-    const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
+
+    const std::wstring &ImagePath() const { return m_imagePath; }
+    const std::wstring &CsvPath() const { return m_csvData; }
+    const std::wstring &OutputPath() const { return m_perfOutputPath; }
+    const std::wstring &FolderPath() const { return m_modelFolderPath; }
+    const std::wstring &ModelPath() const { return m_modelPath; }
+    const std::wstring &TensorOutputPath() const { return m_tensorOutputPath; }
 
     bool UseRGB() const
     {
-        // If an image is specified without flags, we load it as a BGR image by default
+        // If an image is specified without flags, we load it as a BGR image by
+        // default
         return m_useRGB || (!m_imagePath.empty() && !m_useBGR && !m_useTensor);
     }
 
@@ -43,10 +44,7 @@ public:
         return m_useTensor || (!m_useBGR && !UseRGB());
     }
 
-    bool UseGPU() const
-    {
-        return m_useGPU || (!m_useCPU && !m_useGPUHighPerformance && !m_useGPUMinPower);
-    }
+    bool UseGPU() const { return m_useGPU || (!m_useCPU && !m_useGPUHighPerformance && !m_useGPUMinPower); }
 
     bool UseCPU() const
     {
@@ -68,7 +66,8 @@ public:
 
     bool IsGarbageInput() const
     {
-        // When there is no image or csv input provided, then garbage input binding is used.
+        // When there is no image or csv input provided, then garbage input
+        // binding is used.
         return m_imagePath.empty() && m_csvData.empty();
     }
 
@@ -85,32 +84,28 @@ public:
     void ToggleCreateDeviceInWinML(bool createDeviceInWinML) { m_createDeviceInWinML = createDeviceInWinML; }
     void ToggleCPUBoundInput(bool useCPUBoundInput) { m_useCPUBoundInput = useCPUBoundInput; }
     void ToggleGPUBoundInput(bool useGPUBoundInput) { m_useGPUBoundInput = useGPUBoundInput; }
-    void ToggleUseRGB(bool useRGBImage) {m_useRGB = useRGBImage;}
-    void ToggleUseBGR(bool useBGRImage) {m_useBGR = useBGRImage;}
+    void ToggleUseRGB(bool useRGBImage) { m_useRGB = useRGBImage; }
+    void ToggleUseBGR(bool useBGRImage) { m_useBGR = useBGRImage; }
     void ToggleUseTensor(bool useTensor) { m_useTensor = useTensor; }
     void TogglePerformanceCapture(bool perfCapture) { m_perfCapture = perfCapture; }
-    void ToggleIgnoreFirstRun(bool ignoreFirstRun) { m_ignoreFirstRun=ignoreFirstRun;}
+    void ToggleIgnoreFirstRun(bool ignoreFirstRun) { m_ignoreFirstRun = ignoreFirstRun; }
     void TogglePerIterationPerformanceCapture(bool perIterCapture) { m_perIterCapture = perIterCapture; }
     void ToggleEvaluationDebugOutput(bool debug) { m_evaluation_debug_output = debug; }
     void ToggleTerseOutput(bool terseOutput) { m_terseOutput = terseOutput; }
 
-
-    void SetModelPath(const std::wstring& modelPath) { m_modelPath = modelPath; }
-    void SetTensorOutputPath(const std::wstring& tensorOutputPath) { m_tensorOutputPath = tensorOutputPath; }
-    void SetInputDataPath(const std::wstring& inputDataPath) { m_inputData = inputDataPath; }
+    void SetModelPath(const std::wstring &modelPath) { m_modelPath = modelPath; }
+    void SetTensorOutputPath(const std::wstring &tensorOutputPath) { m_tensorOutputPath = tensorOutputPath; }
+    void SetInputDataPath(const std::wstring &inputDataPath) { m_inputData = inputDataPath; }
     void SetNumThreads(unsigned numThreads) { m_numThreads = numThreads; }
     void SetThreadInterval(unsigned threadInterval) { m_threadInterval = threadInterval; }
-    void SetPerformanceCSVPath(const std::wstring& performanceCSVPath)
+    void SetPerformanceCSVPath(const std::wstring &performanceCSVPath)
     {
         m_perfOutputPath = performanceCSVPath;
         m_perfOutput = true;
     }
     void SetRunIterations(const uint32_t iterations) { m_numIterations = iterations; }
 
-    std::string SaveTensorMode() const
-    {
-        return m_saveTensorMode;
-    }
+    std::string SaveTensorMode() const { return m_saveTensorMode; }
 
 private:
     bool m_perfCapture = false;

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -3,38 +3,37 @@
 #define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 #endif
 // unknown.h needs to be inlcuded before any winrt headers
+#include "DirectXPackedVector.h"
+#include "TimerHelper.h"
+#include "TypeHelper.h"
+#include <algorithm>
+#include <cassert>
+#include <comdef.h>
+#include <dxgi1_6.h>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <string>
 #include <unknwn.h>
+#include <vector>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Media.h>
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Media.h>
-#include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Streams.h>
-#include <vector>
-#include <string>
-#include <iostream>
-#include <sstream>
-#include <comdef.h>
-#include <algorithm>
-#include <numeric>
-#include <cassert>
-#include <fstream>
-#include <dxgi1_6.h>
-#include "TypeHelper.h"
-#include "TimerHelper.h"
-#include "DirectXPackedVector.h"
+#include <winrt/Windows.Storage.h>
 
 enum WINML_MODEL_TEST_PERF
 {
-	ENTIRE_TEST = 0,
-	LOAD_MODEL,
-	CREATE_SESSION,
-	BIND_VALUE,
-	EVAL_MODEL,
+    ENTIRE_TEST = 0,
+    LOAD_MODEL,
+    CREATE_SESSION,
+    BIND_VALUE,
+    EVAL_MODEL,
     BIND_VALUE_FIRST_RUN,
-	EVAL_MODEL_FIRST_RUN,
-	COUNT
+    EVAL_MODEL_FIRST_RUN,
+    COUNT
 };
 
 #define MAX_PROFILING_LOOP 100
@@ -43,42 +42,39 @@ using namespace winrt;
 
 inline std::wstring MakeErrorMsg(HRESULT hr)
 {
-	std::wostringstream ss;
-	ss << L"0x" << std::hex << hr << ": " << _com_error(hr).ErrorMessage();
-	return ss.str();
+    std::wostringstream ss;
+    ss << L"0x" << std::hex << hr << ": " << _com_error(hr).ErrorMessage();
+    return ss.str();
 }
 
 inline std::wstring MakeErrorMsg(HRESULT hr, const std::wstring &errorMsg)
 {
-	std::wostringstream ss;
-	ss << errorMsg << L" (" << (MakeErrorMsg(hr)) << L")";
-	return ss.str();
+    std::wostringstream ss;
+    ss << errorMsg << L" (" << (MakeErrorMsg(hr)) << L")";
+    return ss.str();
 }
 
 inline void WriteErrorMsg(const std::wstring &errorMsg)
 {
-	std::wostringstream ss;
-	ss << L"ERROR: " << errorMsg << std::endl;
-	OutputDebugStringW(ss.str().c_str());
-	std::wcout << ss.str() << std::endl;
+    std::wostringstream ss;
+    ss << L"ERROR: " << errorMsg << std::endl;
+    OutputDebugStringW(ss.str().c_str());
+    std::wcout << ss.str() << std::endl;
 }
 
 inline void WriteErrorMsg(HRESULT hr, const std::wstring &errorMsg = L"")
 {
-	std::wostringstream ss;
-	ss << errorMsg << L" (" << (MakeErrorMsg(hr)) << L")";
-	WriteErrorMsg(ss.str());
+    std::wostringstream ss;
+    ss << errorMsg << L" (" << (MakeErrorMsg(hr)) << L")";
+    WriteErrorMsg(ss.str());
 }
 
 inline void ThrowIfFailed(HRESULT hr, const std::wstring &errorMsg = L"")
 {
-	if (FAILED(hr))
-	{
-		throw MakeErrorMsg(hr, errorMsg);
-	}
+    if (FAILED(hr))
+    {
+        throw MakeErrorMsg(hr, errorMsg);
+    }
 }
 
-inline void ThrowFailure(const std::wstring &errorMsg)
-{
-	throw errorMsg;
-}
+inline void ThrowFailure(const std::wstring &errorMsg) { throw errorMsg; }

--- a/Tools/WinMLRunner/src/Concurrency.cpp
+++ b/Tools/WinMLRunner/src/Concurrency.cpp
@@ -1,44 +1,45 @@
 #include <iostream>
-#include <thread>
 #include <regex>
+#include <thread>
 
+#include "ThreadPool.h"
 #include "Windows.h"
 #include "common.h"
-#include "ThreadPool.h"
 
 using namespace winrt;
 using namespace winrt::Windows::AI::MachineLearning;
 
-void load_model(const std::wstring &path, bool print_info)
+void load_model(const std::wstring& path, bool print_info)
 {
-  if (print_info)
-  {
-    std::wstringstream ss;
-    ss <<  L"Begin loading a model " << path << L" in thread " << std::this_thread::get_id() << std::endl;
-    std::wcout << ss.str();
-  }
-  auto model = LearningModel::LoadFromFilePath(path);
-  if (print_info)
-  {
-    std::wstringstream ss;
-    ss << L"End loading a model in thread " << std::this_thread::get_id() << std::endl;
-    std::wcout << ss.str();
-  }
+    if (print_info)
+    {
+        std::wstringstream ss;
+        ss << L"Begin loading a model " << path << L" in thread " << std::this_thread::get_id() << std::endl;
+        std::wcout << ss.str();
+    }
+    auto model = LearningModel::LoadFromFilePath(path);
+    if (print_info)
+    {
+        std::wstringstream ss;
+        ss << L"End loading a model in thread " << std::this_thread::get_id() << std::endl;
+        std::wcout << ss.str();
+    }
 }
 
-void ConcurrentLoadModel(const std::vector<std::wstring> &paths, unsigned num_threads,
-                         unsigned interval_milliseconds, bool print_info)
+void ConcurrentLoadModel(const std::vector<std::wstring>& paths, unsigned num_threads, unsigned interval_milliseconds,
+                         bool print_info)
 {
 
-  ThreadPool pool(num_threads);
-  // Creating enough threads to load all the models specified
-  // If there is more than enough threads, some threads will concurrently load same models
-  size_t threads_size = paths.size() > num_threads ? paths.size() : num_threads;
-  std::vector<std::future<void>> output_futures;
-  for (size_t i = 0; i < threads_size; i++)
-  {
-      Sleep(interval_milliseconds);
-      output_futures.push_back(pool.SubmitWork(load_model, std::ref(paths[i % paths.size()]), true));
-  }
-  // TODO: read output values from load_model
+    ThreadPool pool(num_threads);
+    // Creating enough threads to load all the models specified
+    // If there is more than enough threads, some threads will concurrently load
+    // same models
+    size_t threads_size = paths.size() > num_threads ? paths.size() : num_threads;
+    std::vector<std::future<void>> output_futures;
+    for (size_t i = 0; i < threads_size; i++)
+    {
+        Sleep(interval_milliseconds);
+        output_futures.push_back(pool.SubmitWork(load_model, std::ref(paths[i % paths.size()]), true));
+    }
+    // TODO: read output values from load_model
 }

--- a/Tools/WinMLRunner/src/Filehelper.cpp
+++ b/Tools/WinMLRunner/src/Filehelper.cpp
@@ -6,20 +6,20 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 namespace FileHelper
 {
-    std::wstring GetModulePath()
-    {
-        std::wstring val;
-        wchar_t modulePath[MAX_PATH] = { 0 };
-        GetModuleFileNameW((HINSTANCE)&__ImageBase, modulePath, _countof(modulePath));
-        wchar_t drive[_MAX_DRIVE];
-        wchar_t dir[_MAX_DIR];
-        wchar_t filename[_MAX_FNAME];
-        wchar_t ext[_MAX_EXT];
-        errno_t err = _wsplitpath_s(modulePath, drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, ext, _MAX_EXT);
+std::wstring GetModulePath()
+{
+    std::wstring val;
+    wchar_t modulePath[MAX_PATH] = {0};
+    GetModuleFileNameW((HINSTANCE)&__ImageBase, modulePath, _countof(modulePath));
+    wchar_t drive[_MAX_DRIVE];
+    wchar_t dir[_MAX_DIR];
+    wchar_t filename[_MAX_FNAME];
+    wchar_t ext[_MAX_EXT];
+    errno_t err = _wsplitpath_s(modulePath, drive, _MAX_DRIVE, dir, _MAX_DIR, filename, _MAX_FNAME, ext, _MAX_EXT);
 
-        val = drive;
-        val += dir;
+    val = drive;
+    val += dir;
 
-        return val;
-    }
+    return val;
 }
+} // namespace FileHelper

--- a/Tools/WinMLRunner/src/ModelBinding.h
+++ b/Tools/WinMLRunner/src/ModelBinding.h
@@ -2,11 +2,11 @@
 #include "Common.h"
 
 // Stores data and size of input and output bindings.
-template< typename T>
-class ModelBinding
+template <typename T> class ModelBinding
 {
 public:
-    ModelBinding(winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor variableDesc) : m_bindingDesc(variableDesc)
+    ModelBinding(winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor variableDesc)
+        : m_bindingDesc(variableDesc)
     {
         UINT numElements = 0;
         if (variableDesc.Kind() == LearningModelFeatureKind::Tensor)
@@ -19,44 +19,23 @@ public:
         }
     }
 
-    winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor GetDesc()
-    {
-        return m_bindingDesc;
-    }
+    winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor GetDesc() { return m_bindingDesc; }
 
-    UINT GetNumElements() const
-    {
-        return m_numElements;
-    }
+    UINT GetNumElements() const { return m_numElements; }
 
-    UINT GetElementSize() const
-    {
-        return m_elementSize;
-    }
+    UINT GetElementSize() const { return m_elementSize; }
 
-    std::vector<int64_t> GetShapeBuffer()
-    {
-        return m_shapeBuffer;
-    }
+    std::vector<int64_t> GetShapeBuffer() { return m_shapeBuffer; }
 
-    T* GetData()
-    {
-        return m_dataBuffer.data();
-    }
+    T* GetData() { return m_dataBuffer.data(); }
 
-    std::vector<T> GetDataBuffer()
-    {
-        return m_dataBuffer;
-    }
+    std::vector<T> GetDataBuffer() { return m_dataBuffer; }
 
-    size_t GetDataBufferSize()
-    {
-        return m_dataBuffer.size();
-    }
-
+    size_t GetDataBufferSize() { return m_dataBuffer.size(); }
 
 private:
-    void InitNumElementsAndShape(winrt::Windows::Foundation::Collections::IVectorView<int64_t> * shape, UINT numDimensions, UINT numElements)
+    void InitNumElementsAndShape(winrt::Windows::Foundation::Collections::IVectorView<int64_t>* shape,
+                                 UINT numDimensions, UINT numElements)
     {
         int unknownDim = -1;
         UINT numKnownElements = 1;
@@ -81,7 +60,8 @@ private:
         m_numElements = numKnownElements;
     }
 
-    void InitTensorBinding(winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor descriptor, UINT numElements)
+    void InitTensorBinding(winrt::Windows::AI::MachineLearning::ILearningModelFeatureDescriptor descriptor,
+                           UINT numElements)
     {
         auto tensorDescriptor = descriptor.as<winrt::Windows::AI::MachineLearning::TensorFeatureDescriptor>();
         InitNumElementsAndShape(&tensorDescriptor.Shape(), tensorDescriptor.Shape().Size(), 1);

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -1,15 +1,15 @@
 #pragma once
-#include "Common.h"
 #include "CommandLineArgs.h"
-#include <fstream>
+#include "Common.h"
+#include <Windows.Graphics.DirectX.Direct3D11.interop.h>
+#include <codecvt>
 #include <ctime>
+#include <direct.h>
+#include <dxgi.h>
+#include <fstream>
+#include <iomanip>
 #include <locale>
 #include <utility>
-#include <codecvt>
-#include <iomanip>
-#include <dxgi.h>
-#include <Windows.Graphics.DirectX.Direct3D11.interop.h>
-#include <direct.h>
 
 using namespace winrt::Windows::AI::MachineLearning;
 using namespace winrt::Windows::Storage::Streams;
@@ -17,7 +17,7 @@ using namespace ::Windows::Graphics::DirectX::Direct3D11;
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 using namespace DirectX::PackedVector;
 
-inline size_t hash_data(void const* ptr, size_t const bytes) noexcept
+inline size_t hash_data(void const *ptr, size_t const bytes) noexcept
 {
 #ifdef _WIN64
     constexpr size_t fnv_offset_basis = 14695981039346656037ULL;
@@ -27,7 +27,7 @@ inline size_t hash_data(void const* ptr, size_t const bytes) noexcept
     constexpr size_t fnv_prime = 16777619U;
 #endif
     size_t result = fnv_offset_basis;
-    uint8_t const* const buffer = static_cast<uint8_t const*>(ptr);
+    uint8_t const *const buffer = static_cast<uint8_t const *>(ptr);
 
     for (size_t next = 0; next < bytes; ++next)
     {
@@ -56,35 +56,31 @@ public:
         m_outputTensorHash.resize(numIterations, 0);
     }
 
-    void PrintLoadingInfo(const std::wstring& modelPath) const
+    void PrintLoadingInfo(const std::wstring &modelPath) const
     {
         wprintf(L"Loading model (path = %s)...\n", modelPath.c_str());
     }
 
-    void PrintBindingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation, const std::string& status) const
+    void PrintBindingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType,
+                          InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation,
+                          const std::string &status) const
     {
-        printf(
-            "Binding (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s)...%s\n",
-            TypeHelper::Stringify(deviceType).c_str(),
-            iteration,
-            TypeHelper::Stringify(inputBindingType).c_str(),
-            TypeHelper::Stringify(inputDataType).c_str(),
-            TypeHelper::Stringify(deviceCreationLocation).c_str(),
-            status.c_str()
-        );
+        printf("Binding (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = "
+               "%s)...%s\n",
+               TypeHelper::Stringify(deviceType).c_str(), iteration, TypeHelper::Stringify(inputBindingType).c_str(),
+               TypeHelper::Stringify(inputDataType).c_str(), TypeHelper::Stringify(deviceCreationLocation).c_str(),
+               status.c_str());
     }
 
-    void PrintEvaluatingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation, const std::string &status) const
+    void PrintEvaluatingInfo(uint32_t iteration, DeviceType deviceType, InputBindingType inputBindingType,
+                             InputDataType inputDataType, DeviceCreationLocation deviceCreationLocation,
+                             const std::string &status) const
     {
-        printf(
-            "Evaluating (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s)...%s\n",
-            TypeHelper::Stringify(deviceType).c_str(),
-            iteration,
-            TypeHelper::Stringify(inputBindingType).c_str(),
-            TypeHelper::Stringify(inputDataType).c_str(),
-            TypeHelper::Stringify(deviceCreationLocation).c_str(),
-            status.c_str()
-        );
+        printf("Evaluating (device = %s, iteration = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation "
+               "= %s)...%s\n",
+               TypeHelper::Stringify(deviceType).c_str(), iteration, TypeHelper::Stringify(inputBindingType).c_str(),
+               TypeHelper::Stringify(inputDataType).c_str(), TypeHelper::Stringify(deviceCreationLocation).c_str(),
+               status.c_str());
     }
 
     void PrintModelInfo(std::wstring modelPath, LearningModel model) const
@@ -99,15 +95,15 @@ public:
         std::cout << "Support FP16: " << std::boolalpha << doesModelContainFP16(model) << std::endl;
 
         std::cout << std::endl;
-        //print out information about input of model
+        // print out information about input of model
         std::cout << "Input Feature Info:" << std::endl;
-        for (auto&& inputFeature : model.InputFeatures())
+        for (auto &&inputFeature : model.InputFeatures())
         {
             PrintFeatureDescriptorInfo(inputFeature);
         }
-        //print out information about output of model
+        // print out information about output of model
         std::cout << "Output Feature Info:" << std::endl;
-        for (auto&& outputFeature : model.OutputFeatures())
+        for (auto &&outputFeature : model.OutputFeatures())
         {
             PrintFeatureDescriptorInfo(outputFeature);
         }
@@ -117,10 +113,9 @@ public:
 
     void PrintFeatureDescriptorInfo(const ILearningModelFeatureDescriptor &descriptor) const
     {
-        //IMPORTANT: This learningModelFeatureKind array needs to match the "enum class 
-        //LearningModelFeatureKind" idl in Windows.AI.MachineLearning.0.h
-        const std::string learningModelFeatureKind[] =
-        {
+        // IMPORTANT: This learningModelFeatureKind array needs to match the "enum class
+        // LearningModelFeatureKind" idl in Windows.AI.MachineLearning.0.h
+        const std::string learningModelFeatureKind[] = {
             "Tensor",
             "Sequence",
             "Map",
@@ -138,21 +133,25 @@ public:
         std::cout << "Printing available GPUs with DXGI.." << std::endl;
         com_ptr<IDXGIFactory6> factory;
         CreateDXGIFactory1(__uuidof(IDXGIFactory6), factory.put_void());
-        std::vector <com_ptr<IDXGIAdapter1>> validAdapters;
-        for (UINT i = 0; ; ++i) {
+        std::vector<com_ptr<IDXGIAdapter1>> validAdapters;
+        for (UINT i = 0;; ++i)
+        {
             com_ptr<IDXGIAdapter1> spAdapter;
-            if (factory->EnumAdapters1(i, spAdapter.put()) != S_OK) {
+            if (factory->EnumAdapters1(i, spAdapter.put()) != S_OK)
+            {
                 break;
             }
             DXGI_ADAPTER_DESC1 pDesc;
             spAdapter->GetDesc1(&pDesc);
 
             // is a software adapter
-            if (pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE || (pDesc.VendorId == 0x1414 && pDesc.DeviceId == 0x8c)) {
+            if (pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE || (pDesc.VendorId == 0x1414 && pDesc.DeviceId == 0x8c))
+            {
                 continue;
             }
             // valid GPU adapter
-            else {
+            else
+            {
                 printf("Index: %d, Description: %ls\n", static_cast<int>(validAdapters.size()), pDesc.Description);
                 validAdapters.push_back(spAdapter);
             }
@@ -160,7 +159,7 @@ public:
         std::cout << std::endl;
     }
 
-    void PrintLearningModelDevice(DeviceType deviceType, const LearningModelDevice& device)
+    void PrintLearningModelDevice(DeviceType deviceType, const LearningModelDevice &device)
     {
         if (deviceType == DeviceType::CPU)
         {
@@ -189,15 +188,9 @@ public:
         }
     }
 
-    void PrintResults(
-        const Profiler<WINML_MODEL_TEST_PERF> &profiler,
-        uint32_t numIterations,
-        DeviceType deviceType,
-        InputBindingType inputBindingType,
-        InputDataType inputDataType,
-        DeviceCreationLocation deviceCreationLocation,
-        bool isPerformanceConsoleOutputVerbose
-    ) const
+    void PrintResults(const Profiler<WINML_MODEL_TEST_PERF> &profiler, uint32_t numIterations, DeviceType deviceType,
+                      InputBindingType inputBindingType, InputDataType inputDataType,
+                      DeviceCreationLocation deviceCreationLocation, bool isPerformanceConsoleOutputVerbose) const
     {
         double loadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
         double createSessionTime = profiler[CREATE_SESSION].GetAverage(CounterType::TIMER);
@@ -217,42 +210,52 @@ public:
         double firstLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double firstLoadPeakWorkingSetUsage = profiler[LOAD_MODEL].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
-        double firstSessionCreationWorkingSetMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstSessionCreationSharedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstSessionCreationDedicatedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstSessionPeakWorkingSetUsage = profiler[CREATE_SESSION].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
+        double firstSessionCreationWorkingSetMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
+        double firstSessionCreationSharedMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstSessionCreationDedicatedMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstSessionPeakWorkingSetUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageBindMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::WORKING_SET_USAGE);
         double minBindMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::WORKING_SET_USAGE);
         double maxBindMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::WORKING_SET_USAGE);
         double firstBindMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstBindPeakMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
+        double firstBindPeakMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageEvalMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
         double minEvalMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::WORKING_SET_USAGE);
         double maxEvalMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::WORKING_SET_USAGE);
         double firstEvalMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstEvalPeakMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
+        double firstEvalPeakMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::PEAK_WORKING_SET_USAGE);
 
         double averageBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstBindDedicatedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstBindDedicatedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstEvalDedicatedMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstEvalDedicatedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageBindSharedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double minBindSharedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxBindSharedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstBindSharedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstBindSharedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
 
         double averageEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double minEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstEvalSharedMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstEvalSharedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
 
         double firstIterationWorkingSetMemoryUsage =
             profiler[LOAD_MODEL].GetAverage(CounterType::WORKING_SET_USAGE) +
@@ -272,15 +275,14 @@ public:
             profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE) +
             profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
-        double firstIterationPeakWorkingSet = firstLoadPeakWorkingSetUsage + firstSessionPeakWorkingSetUsage + firstBindPeakMemoryUsage + firstEvalPeakMemoryUsage;
+        double firstIterationPeakWorkingSet = firstLoadPeakWorkingSetUsage + firstSessionPeakWorkingSetUsage +
+                                              firstBindPeakMemoryUsage + firstEvalPeakMemoryUsage;
 
-        printf("\nResults (device = %s, numIterations = %d, inputBinding = %s, inputDataType = %s, deviceCreationLocation = %s):\n",
-            TypeHelper::Stringify(deviceType).c_str(),
-            numIterations,
-            TypeHelper::Stringify(inputBindingType).c_str(),
-            TypeHelper::Stringify(inputDataType).c_str(),
-            TypeHelper::Stringify(deviceCreationLocation).c_str()
-        );
+        printf("\nResults (device = %s, numIterations = %d, inputBinding = %s, inputDataType = %s, "
+               "deviceCreationLocation = %s):\n",
+               TypeHelper::Stringify(deviceType).c_str(), numIterations,
+               TypeHelper::Stringify(inputBindingType).c_str(), TypeHelper::Stringify(inputDataType).c_str(),
+               TypeHelper::Stringify(deviceCreationLocation).c_str());
 
         std::cout << "\nFirst Iteration Performance (load, bind, session creation, and evaluate): " << std::endl;
         std::cout << "  Load: " << loadTime << " ms" << std::endl;
@@ -290,8 +292,10 @@ public:
 
         if (isPerformanceConsoleOutputVerbose)
         {
-            std::cout << "\n  Working Set Memory usage (load): " << firstLoadWorkingSetMemoryUsage << " MB" << std::endl;
-            std::cout << "  Working Set Memory usage (session creation): " << firstSessionCreationWorkingSetMemoryUsage << " MB" << std::endl;
+            std::cout << "\n  Working Set Memory usage (load): " << firstLoadWorkingSetMemoryUsage << " MB"
+                      << std::endl;
+            std::cout << "  Working Set Memory usage (session creation): " << firstSessionCreationWorkingSetMemoryUsage
+                      << " MB" << std::endl;
             std::cout << "  Working Set Memory usage (bind): " << firstBindMemoryUsage << " MB" << std::endl;
         }
         else
@@ -299,23 +303,30 @@ public:
             std::cout << std::endl;
         }
         std::cout << "  Working Set Memory usage (evaluate): " << firstEvalMemoryUsage << " MB" << std::endl;
-        std::cout << "  Working Set Memory usage (load, bind, session creation, and evaluate): " << firstIterationWorkingSetMemoryUsage << " MB" << std::endl;
+        std::cout << "  Working Set Memory usage (load, bind, session creation, and evaluate): "
+                  << firstIterationWorkingSetMemoryUsage << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)
         {
             std::cout << std::endl;
-            std::cout << "  Peak Working Set Memory Difference (from start to load): " << firstLoadPeakWorkingSetUsage << " MB" << std::endl;
-            std::cout << "  Peak Working Set Memory Difference (from model load to session creation): " << firstSessionPeakWorkingSetUsage << " MB" << std::endl;
-            std::cout << "  Peak Working Set Memory Difference (from session to bind): " << firstBindPeakMemoryUsage << " MB" << std::endl;
-            std::cout << "  Peak Working Set Memory Difference (from bind to evaluate): " << firstEvalPeakMemoryUsage << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from start to load): " << firstLoadPeakWorkingSetUsage
+                      << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from model load to session creation): "
+                      << firstSessionPeakWorkingSetUsage << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from session to bind): " << firstBindPeakMemoryUsage
+                      << " MB" << std::endl;
+            std::cout << "  Peak Working Set Memory Difference (from bind to evaluate): " << firstEvalPeakMemoryUsage
+                      << " MB" << std::endl;
         }
 
-        std::cout << "  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): " << firstIterationPeakWorkingSet << " MB" << std::endl;
+        std::cout << "  Peak Working Set Memory Difference (load, bind, session creation, and evaluate): "
+                  << firstIterationPeakWorkingSet << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)
         {
             std::cout << "\n  Dedicated Memory usage (load): " << firstLoadDedicatedMemoryUsage << " MB" << std::endl;
-            std::cout << "  Dedicated Memory usage (session creation): " << firstSessionCreationDedicatedMemoryUsage << " MB" << std::endl;
+            std::cout << "  Dedicated Memory usage (session creation): " << firstSessionCreationDedicatedMemoryUsage
+                      << " MB" << std::endl;
             std::cout << "  Dedicated Memory usage (bind): " << firstBindDedicatedMemoryUsage << " MB" << std::endl;
         }
         else
@@ -323,12 +334,14 @@ public:
             std::cout << std::endl;
         }
         std::cout << "  Dedicated Memory usage (evaluate): " << firstEvalDedicatedMemoryUsage << " MB" << std::endl;
-        std::cout << "  Dedicated Memory usage (load, bind, session creation, and evaluate): " << firstIterationDedicatedMemoryUsage << " MB" << std::endl;
+        std::cout << "  Dedicated Memory usage (load, bind, session creation, and evaluate): "
+                  << firstIterationDedicatedMemoryUsage << " MB" << std::endl;
 
         if (isPerformanceConsoleOutputVerbose)
         {
             std::cout << "\n  Shared Memory usage (load): " << firstLoadSharedMemoryUsage << " MB" << std::endl;
-            std::cout << "  Shared Memory usage (session creation): " << firstSessionCreationSharedMemoryUsage << " MB" << std::endl;
+            std::cout << "  Shared Memory usage (session creation): " << firstSessionCreationSharedMemoryUsage << " MB"
+                      << std::endl;
             std::cout << "  Shared Memory usage (bind): " << firstBindSharedMemoryUsage << " MB" << std::endl;
         }
         else
@@ -336,11 +349,14 @@ public:
             std::cout << std::endl;
         }
         std::cout << "  Shared Memory usage (evaluate): " << firstEvalSharedMemoryUsage << " MB" << std::endl;
-        std::cout << "  Shared Memory usage (load, bind, session creation, and evaluate): " << firstIterationSharedMemoryUsage << " MB" << std::endl;
+        std::cout << "  Shared Memory usage (load, bind, session creation, and evaluate): "
+                  << firstIterationSharedMemoryUsage << " MB" << std::endl;
 
         if (numIterations > 1)
         {
-            printf("\nAverage Performance excluding first iteration. Iterations %d to %d. (Iterations greater than 1 only bind and evaluate)\n", 2, numIterations);
+            printf("\nAverage Performance excluding first iteration. Iterations %d to %d. (Iterations greater than 1 "
+                   "only bind and evaluate)\n",
+                   2, numIterations);
             std::cout << "  Average Bind: " << averageBindTime << " ms" << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
@@ -354,39 +370,49 @@ public:
                 std::cout << "  Maximum Evaluate: " << maxEvalTime << " ms" << std::endl;
             }
 
-            std::cout << "\n  Average Working Set Memory usage (bind): " << averageBindMemoryUsage << " MB" << std::endl;
+            std::cout << "\n  Average Working Set Memory usage (bind): " << averageBindMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
                 std::cout << "  Min Working Set Memory usage (bind): " << minBindMemoryUsage << " MB" << std::endl;
                 std::cout << "  Max Working Set Memory usage (bind): " << maxBindMemoryUsage << " MB" << std::endl;
             }
-            std::cout << "  Average Working Set Memory usage (evaluate): " << averageEvalMemoryUsage << " MB" << std::endl;
+            std::cout << "  Average Working Set Memory usage (evaluate): " << averageEvalMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
                 std::cout << "  Min Working Set Memory usage (evaluate): " << minEvalMemoryUsage << " MB" << std::endl;
                 std::cout << "  Max Working Set Memory usage (evaluate): " << maxEvalMemoryUsage << " MB" << std::endl;
             }
 
-            std::cout << "\n  Average Dedicated Memory usage (bind): " << averageBindDedicatedMemoryUsage << " MB" << std::endl;
+            std::cout << "\n  Average Dedicated Memory usage (bind): " << averageBindDedicatedMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
-                std::cout << "  Min Dedicated Memory usage (bind): " << minBindDedicatedMemoryUsage << " MB" << std::endl;
-                std::cout << "  Max Dedicated Memory usage (bind): " << maxBindDedicatedMemoryUsage << " MB" << std::endl;
+                std::cout << "  Min Dedicated Memory usage (bind): " << minBindDedicatedMemoryUsage << " MB"
+                          << std::endl;
+                std::cout << "  Max Dedicated Memory usage (bind): " << maxBindDedicatedMemoryUsage << " MB"
+                          << std::endl;
             }
-            std::cout << "  Average Dedicated Memory usage (evaluate): " << averageEvalDedicatedMemoryUsage << " MB" << std::endl;
+            std::cout << "  Average Dedicated Memory usage (evaluate): " << averageEvalDedicatedMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
-                std::cout << "  Min Dedicated Memory usage (evaluate): " << minEvalDedicatedMemoryUsage << " MB" << std::endl;
-                std::cout << "  Max Dedicated Memory usage (evaluate): " << maxEvalDedicatedMemoryUsage << " MB" << std::endl;
+                std::cout << "  Min Dedicated Memory usage (evaluate): " << minEvalDedicatedMemoryUsage << " MB"
+                          << std::endl;
+                std::cout << "  Max Dedicated Memory usage (evaluate): " << maxEvalDedicatedMemoryUsage << " MB"
+                          << std::endl;
             }
 
-            std::cout << "\n  Average Shared Memory usage (bind): " << averageBindSharedMemoryUsage << " MB" << std::endl;
+            std::cout << "\n  Average Shared Memory usage (bind): " << averageBindSharedMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
                 std::cout << "  Min Shared Memory usage (bind): " << minBindSharedMemoryUsage << " MB" << std::endl;
                 std::cout << "  Max Shared Memory usage (bind): " << maxBindSharedMemoryUsage << " MB" << std::endl;
             }
-            std::cout << "  Average Shared Memory usage (evaluate): " << averageEvalSharedMemoryUsage << " MB" << std::endl;
+            std::cout << "  Average Shared Memory usage (evaluate): " << averageEvalSharedMemoryUsage << " MB"
+                      << std::endl;
             if (isPerformanceConsoleOutputVerbose)
             {
                 std::cout << "  Min Shared Memory usage (evaluate): " << minEvalSharedMemoryUsage << " MB" << std::endl;
@@ -398,25 +424,11 @@ public:
 
     static std::wstring FeatureDescriptorToString(const ILearningModelFeatureDescriptor &descriptor)
     {
-        //IMPORTANT: This tensorKinds array needs to match the "enum class TensorKind" idl in Windows.AI.MachineLearning.0.h
-        const std::wstring tensorKind[] =
-        {
-            L"Undefined",
-            L"Float",
-            L"UInt8",
-            L"Int8",
-            L"UInt16",
-            L"Int16",
-            L"Int32",
-            L"Int64",
-            L"String",
-            L"Boolean",
-            L"Float16",
-            L"Double",
-            L"UInt32",
-            L"UInt64",
-            L"Complex64",
-            L"Complex128",
+        // IMPORTANT: This tensorKinds array needs to match the "enum class TensorKind" idl in
+        // Windows.AI.MachineLearning.0.h
+        const std::wstring tensorKind[] = {
+            L"Undefined", L"Float",   L"UInt8",   L"Int8",   L"UInt16", L"Int16",  L"Int32",     L"Int64",
+            L"String",    L"Boolean", L"Float16", L"Double", L"UInt32", L"UInt64", L"Complex64", L"Complex128",
         };
         switch (descriptor.Kind())
         {
@@ -428,8 +440,8 @@ public:
         case LearningModelFeatureKind::Image:
         {
             auto imageDescriptor = descriptor.as<ImageFeatureDescriptor>();
-            std::wstring str = L"Image (Height: " + std::to_wstring(imageDescriptor.Height()) +
-                               L", Width:  " + std::to_wstring(imageDescriptor.Width()) + L")";
+            std::wstring str = L"Image (Height: " + std::to_wstring(imageDescriptor.Height()) + L", Width:  " +
+                               std::to_wstring(imageDescriptor.Width()) + L")";
             return str;
         }
         case LearningModelFeatureKind::Map:
@@ -455,38 +467,39 @@ public:
     {
         switch (descriptor.Kind())
         {
-            case LearningModelFeatureKind::Tensor:
+        case LearningModelFeatureKind::Tensor:
+        {
+            return descriptor.as<TensorFeatureDescriptor>().TensorKind() == TensorKind::Float16;
+        }
+        break;
+        case LearningModelFeatureKind::Map:
+        {
+            auto mapDescriptor = descriptor.as<MapFeatureDescriptor>();
+            if (mapDescriptor.KeyKind() == TensorKind::Float16)
             {
-                return descriptor.as<TensorFeatureDescriptor>().TensorKind() == TensorKind::Float16;
+                return true;
             }
-            break;
-            case LearningModelFeatureKind::Map:
-            {
-                auto mapDescriptor = descriptor.as<MapFeatureDescriptor>();
-                if (mapDescriptor.KeyKind() == TensorKind::Float16)
-                {
-                    return true;
-                }
-                return doesDescriptorContainFP16(mapDescriptor.ValueDescriptor());
-            }
-            break;
-            case LearningModelFeatureKind::Sequence:
-            {
-                return doesDescriptorContainFP16(descriptor.as<SequenceFeatureDescriptor>().ElementDescriptor());
-            }
-            break;
-            default:
-            {
-                return false;
-            }
+            return doesDescriptorContainFP16(mapDescriptor.ValueDescriptor());
+        }
+        break;
+        case LearningModelFeatureKind::Sequence:
+        {
+            return doesDescriptorContainFP16(descriptor.as<SequenceFeatureDescriptor>().ElementDescriptor());
+        }
+        break;
+        default:
+        {
+            return false;
+        }
         }
     }
 
     static bool doesModelContainFP16(const LearningModel model)
     {
-        for (auto&& inputFeature : model.InputFeatures())
+        for (auto &&inputFeature : model.InputFeatures())
         {
-            if (doesDescriptorContainFP16(inputFeature)) {
+            if (doesDescriptorContainFP16(inputFeature))
+            {
                 return true;
             }
         }
@@ -516,7 +529,7 @@ public:
         m_outputResult[iterationNum] = result;
         m_outputTensorHash[iterationNum] = hashcode;
     }
-    
+
     void SetDefaultPerIterationFolder(const std::wstring &folderName)
     {
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
@@ -575,19 +588,16 @@ public:
         m_csvFileName = converter.from_bytes(fileName);
     }
 
-    void SetCSVFileName(const std::wstring& fileName)
-    {
-        m_csvFileName = fileName;
-    }
+    void SetCSVFileName(const std::wstring &fileName) { m_csvFileName = fileName; }
 
-    void WritePerIterationPerformance(const CommandLineArgs& args, std::wstring model, std::wstring img)
+    void WritePerIterationPerformance(const CommandLineArgs &args, std::wstring model, std::wstring img)
     {
         if (m_csvFileNamePerIterationSummary.length() > 0)
         {
             bool bNewFile = false;
             std::ifstream fin;
             fin.open(m_csvFileNamePerIterationSummary);
-            std::filebuf* outbuf = fin.rdbuf();
+            std::filebuf *outbuf = fin.rdbuf();
             if (EOF == outbuf->sbumpc())
             {
                 bNewFile = true;
@@ -605,32 +615,49 @@ public:
             {
                 if (args.IsPerIterationCapture())
                 {
-                    fout << "Model Name" << ","
-                         << "Image Name" << ","
-                         << "Iterations" << ","
-                         << "Iteration Number " << ","
-                         << "CPU Working Set Diff (MB)" << ","
-                         << "CPU Working Set Start (MB)" << ","
-                         << "GPU Shared Memory Diff (MB)" << ","
-                         << "GPU Shared Memory Start (MB)" << ","
-                         << "GPU Dedicated Memory Diff (MB)" << ","
-                         << "Load (ms)" << ","
-                         << "Bind (ms)" << ","
-                         << "Evaluate (ms)" << ",";
+                    fout << "Model Name"
+                         << ","
+                         << "Image Name"
+                         << ","
+                         << "Iterations"
+                         << ","
+                         << "Iteration Number "
+                         << ","
+                         << "CPU Working Set Diff (MB)"
+                         << ","
+                         << "CPU Working Set Start (MB)"
+                         << ","
+                         << "GPU Shared Memory Diff (MB)"
+                         << ","
+                         << "GPU Shared Memory Start (MB)"
+                         << ","
+                         << "GPU Dedicated Memory Diff (MB)"
+                         << ","
+                         << "Load (ms)"
+                         << ","
+                         << "Bind (ms)"
+                         << ","
+                         << "Evaluate (ms)"
+                         << ",";
 
                     if (args.IsSaveTensor())
                     {
-                        fout << "Result" << ","
-                             << "OutputTensorHash" << ","
+                        fout << "Result"
+                             << ","
+                             << "OutputTensorHash"
+                             << ","
                              << "FileName";
                     }
                 }
 
                 else if (args.IsSaveTensor())
                 {
-                    fout << "Iteration Number" << ","
-                         << "Result" << ","
-                         << "OutputTensorHash" << ","
+                    fout << "Iteration Number"
+                         << ","
+                         << "Result"
+                         << ","
+                         << "OutputTensorHash"
+                         << ","
                          << "FileName";
                 }
                 fout << std::endl;
@@ -640,24 +667,17 @@ public:
             {
                 for (uint32_t i = 0; i < args.NumIterations(); i++)
                 {
-                    fout << modelName << ","
-                         << imgName << ","
-                         << args.NumIterations() << ","
-                         << i + 1 << ","
-                         << m_CPUWorkingDiff[i] << ","
-                         << m_CPUWorkingStart[i] << ","
-                         << m_GPUSharedDiff[i] << ","
-                         << m_GPUSharedStart[i] << ","
-                         << m_GPUDedicatedDiff[i] << ","
-                         << m_clockLoadTimes[i] << ","
-                         << m_clockBindTimes[i] << ","
-                         << m_clockEvalTimes[i] << ",";
+                    fout << modelName << "," << imgName << "," << args.NumIterations() << "," << i + 1 << ","
+                         << m_CPUWorkingDiff[i] << "," << m_CPUWorkingStart[i] << "," << m_GPUSharedDiff[i] << ","
+                         << m_GPUSharedStart[i] << "," << m_GPUDedicatedDiff[i] << "," << m_clockLoadTimes[i] << ","
+                         << m_clockBindTimes[i] << "," << m_clockEvalTimes[i] << ",";
 
-                    if (args.IsSaveTensor() && (args.SaveTensorMode() == "All" || (args.SaveTensorMode() == "First" && i == 0)))
+                    if (args.IsSaveTensor() &&
+                        (args.SaveTensorMode() == "All" || (args.SaveTensorMode() == "First" && i == 0)))
                     {
-                        fout << m_outputResult[i] << ","
-                             << m_outputTensorHash[i] << ","
-                             << m_fileNameResultDevice + std::to_string(i + 1) + ".csv" << ",";
+                        fout << m_outputResult[i] << "," << m_outputTensorHash[i] << ","
+                             << m_fileNameResultDevice + std::to_string(i + 1) + ".csv"
+                             << ",";
                     }
                     fout << std::endl;
                 }
@@ -666,9 +686,7 @@ public:
             {
                 for (uint32_t i = 0; i < args.NumIterations(); i++)
                 {
-                    fout << i + 1 << ","
-                         << m_outputResult[i] << ","
-                         << m_outputTensorHash[i] << ","
+                    fout << i + 1 << "," << m_outputResult[i] << "," << m_outputTensorHash[i] << ","
                          << m_fileNameResultDevice + std::to_string(i + 1) + ".csv" << std::endl;
                     if (args.SaveTensorMode() == "First" && i == 0)
                     {
@@ -680,15 +698,11 @@ public:
         }
     }
 
-    template<typename T>
-    void ProcessTensorResult(const CommandLineArgs& args,
-                             const void* buffer,
-                             const uint32_t uCapacity,
-                             float& maxValue,
-                             int& maxIndex,
-                             std::ofstream& fout)
+    template <typename T>
+    void ProcessTensorResult(const CommandLineArgs &args, const void *buffer, const uint32_t uCapacity, float &maxValue,
+                             int &maxIndex, std::ofstream &fout)
     {
-        T* tensor = (T*)buffer;
+        T *tensor = (T *)buffer;
         int size = uCapacity / sizeof(T);
         if (!std::is_same<T, HALF>::value)
         {
@@ -721,15 +735,10 @@ public:
             }
         }
     }
-    
-    void WritePerformanceDataToCSV(
-        const Profiler<WINML_MODEL_TEST_PERF> &profiler,
-        int numIterations, std::wstring model,
-        const std::string& deviceType,
-        const std::string& inputBinding,
-        const std::string& inputType,
-        const std::string& deviceCreationLocation
-    ) const
+
+    void WritePerformanceDataToCSV(const Profiler<WINML_MODEL_TEST_PERF> &profiler, int numIterations,
+                                   std::wstring model, const std::string &deviceType, const std::string &inputBinding,
+                                   const std::string &inputType, const std::string &deviceCreationLocation) const
     {
         double loadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
         double createSessionTime = profiler[CREATE_SESSION].GetAverage(CounterType::TIMER);
@@ -748,9 +757,12 @@ public:
         double firstLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double firstLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
-        double firstSessionCreationWorkingSetMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstSessionCreationSharedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstSessionCreationDedicatedMemoryUsage = profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstSessionCreationWorkingSetMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
+        double firstSessionCreationSharedMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstSessionCreationDedicatedMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageBindMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::WORKING_SET_USAGE);
         double minBindMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::WORKING_SET_USAGE);
@@ -765,22 +777,26 @@ public:
         double averageBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstBindDedicatedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstBindDedicatedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstEvalDedicatedMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double firstEvalDedicatedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageBindSharedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double minBindSharedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxBindSharedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstBindSharedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstBindSharedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
 
         double averageEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double minEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstEvalSharedMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double firstEvalSharedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
 
         if (!m_csvFileName.empty())
         {
@@ -788,7 +804,7 @@ public:
             bool bNewFile = false;
             std::ifstream fin;
             fin.open(m_csvFileName);
-            std::filebuf* outbuf = fin.rdbuf();
+            std::filebuf *outbuf = fin.rdbuf();
             if (EOF == outbuf->sbumpc())
             {
                 bNewFile = true;
@@ -800,102 +816,128 @@ public:
 
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             std::string modelName = converter.to_bytes(model);
-       
+
             if (bNewFile)
             {
-                fout << "model name" << ","
-                     << "device type" << ","
-                     << "input binding" << ","
-                     << "input type" << ","
-                     << "device creation location" << ","
-                     << "iterations" << ","
-                     << "load (ms)" << ","
-                     << "session creation (ms)" << ","
-                     << "first bind (ms)" << ","
-                     << "average bind (ms)" << ","
-                     << "min bind (ms)" << ","
-                     << "max bind (ms)" << ","
-                     << "first evaluate (ms)" << ","
-                     << "average evaluate (ms)" << ","
-                     << "min evaluate (ms)" << ","
-                     << "max evaluate (ms)" << ","
-                     << "load working set memory (MB)" << ","
-                     << "session creation working set memory (MB)" << ","
-                     << "first bind working set memory (MB)" << ","
-                     << "bind average working set memory (MB)" << ","
-                     << "bind max working set memory (MB)" << ","
-                     << "bind min working set memory (MB)" << ","
-                     << "first evaluate working set memory (MB)" << ","
-                     << "evaluate average working set memory (MB)" << ","
-                     << "evaluate max working set memory (MB)" << ","
-                     << "evaluate min working set memory (MB)" << ","
-                     << "load dedicated memory (MB)" << ","
-                     << "session creation dedicated memory (MB)" << ","
-                     << "first bind dedicated memory (MB)" << ","
-                     << "bind average dedicated memory (MB)" << ","
-                     << "bind max dedicated memory (MB)" << ","
-                     << "bind min dedicated memory (MB)" << ","
-                     << "first evaluate dedicated memory (MB)" << ","
-                     << "evaluate average dedicated memory (MB)" << ","
-                     << "evaluate max dedicated memory (MB)" << ","
-                     << "evaluate min dedicated memory (MB)" << ","
-                     << "load shared memory (MB)" << ","
-                     << "session creation shared memory (MB)" << ","
-                     << "first bind shared memory (MB)" << ","
-                     << "bind average shared memory (MB)" << ","
-                     << "bind max shared memory (MB)" << ","
-                     << "bind min shared memory (MB)" << ","
-                     << "first evaluate shared memory (MB)" << ","
-                     << "evaluate average shared memory (MB)" << ","
-                     << "evaluate max shared memory (MB)" << ","
+                fout << "model name"
+                     << ","
+                     << "device type"
+                     << ","
+                     << "input binding"
+                     << ","
+                     << "input type"
+                     << ","
+                     << "device creation location"
+                     << ","
+                     << "iterations"
+                     << ","
+                     << "load (ms)"
+                     << ","
+                     << "session creation (ms)"
+                     << ","
+                     << "first bind (ms)"
+                     << ","
+                     << "average bind (ms)"
+                     << ","
+                     << "min bind (ms)"
+                     << ","
+                     << "max bind (ms)"
+                     << ","
+                     << "first evaluate (ms)"
+                     << ","
+                     << "average evaluate (ms)"
+                     << ","
+                     << "min evaluate (ms)"
+                     << ","
+                     << "max evaluate (ms)"
+                     << ","
+                     << "load working set memory (MB)"
+                     << ","
+                     << "session creation working set memory (MB)"
+                     << ","
+                     << "first bind working set memory (MB)"
+                     << ","
+                     << "bind average working set memory (MB)"
+                     << ","
+                     << "bind max working set memory (MB)"
+                     << ","
+                     << "bind min working set memory (MB)"
+                     << ","
+                     << "first evaluate working set memory (MB)"
+                     << ","
+                     << "evaluate average working set memory (MB)"
+                     << ","
+                     << "evaluate max working set memory (MB)"
+                     << ","
+                     << "evaluate min working set memory (MB)"
+                     << ","
+                     << "load dedicated memory (MB)"
+                     << ","
+                     << "session creation dedicated memory (MB)"
+                     << ","
+                     << "first bind dedicated memory (MB)"
+                     << ","
+                     << "bind average dedicated memory (MB)"
+                     << ","
+                     << "bind max dedicated memory (MB)"
+                     << ","
+                     << "bind min dedicated memory (MB)"
+                     << ","
+                     << "first evaluate dedicated memory (MB)"
+                     << ","
+                     << "evaluate average dedicated memory (MB)"
+                     << ","
+                     << "evaluate max dedicated memory (MB)"
+                     << ","
+                     << "evaluate min dedicated memory (MB)"
+                     << ","
+                     << "load shared memory (MB)"
+                     << ","
+                     << "session creation shared memory (MB)"
+                     << ","
+                     << "first bind shared memory (MB)"
+                     << ","
+                     << "bind average shared memory (MB)"
+                     << ","
+                     << "bind max shared memory (MB)"
+                     << ","
+                     << "bind min shared memory (MB)"
+                     << ","
+                     << "first evaluate shared memory (MB)"
+                     << ","
+                     << "evaluate average shared memory (MB)"
+                     << ","
+                     << "evaluate max shared memory (MB)"
+                     << ","
                      << "evaluate min shared memory (MB)" << std::endl;
             }
-            fout << modelName << ","
-                 << deviceType << ","
-                 << inputBinding << ","
-                 << inputType << ","
-                 << deviceCreationLocation << ","
-                 << numIterations << ","
-                 << loadTime << ","
-                 << createSessionTime << ","
-                 << firstBindTime << ","
-                 << ( numIterations <= 1 ? 0 : averageBindTime ) << ","
-                 << ( numIterations <= 1 ? 0 : minBindTime ) << ","
-                 << ( numIterations <= 1 ? 0 : maxBindTime ) << ","
-                 << firstEvalTime << ","
-                 << ( numIterations <= 1 ? 0 : averageEvalTime ) << ","
-                 << ( numIterations <= 1 ? 0 : minEvalTime ) << ","
-                 << ( numIterations <= 1 ? 0 : maxEvalTime ) << ","
-                 << firstLoadWorkingSetMemoryUsage << ","
-                 << firstSessionCreationWorkingSetMemoryUsage << ","
-                 << firstBindMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageBindMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxBindMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minBindMemoryUsage ) << ","
-                 << firstEvalMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageEvalMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxEvalMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minEvalMemoryUsage ) << ","
-                 << firstLoadDedicatedMemoryUsage << ","
-                 << firstSessionCreationDedicatedMemoryUsage << ","
-                 << firstBindDedicatedMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageBindDedicatedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxBindDedicatedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minBindDedicatedMemoryUsage ) << ","
-                 << firstEvalDedicatedMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageEvalDedicatedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxEvalDedicatedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minEvalDedicatedMemoryUsage ) << ","
-                 << firstLoadSharedMemoryUsage << ","
-                 << firstSessionCreationSharedMemoryUsage << ","
-                 << firstBindSharedMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageBindSharedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxBindSharedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minBindSharedMemoryUsage ) << ","
-                 << firstEvalSharedMemoryUsage << ","
-                 << ( numIterations <= 1 ? 0 : averageEvalSharedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : maxEvalSharedMemoryUsage ) << ","
-                 << ( numIterations <= 1 ? 0 : minEvalSharedMemoryUsage ) << "," << std::endl;
+            fout << modelName << "," << deviceType << "," << inputBinding << "," << inputType << ","
+                 << deviceCreationLocation << "," << numIterations << "," << loadTime << "," << createSessionTime << ","
+                 << firstBindTime << "," << (numIterations <= 1 ? 0 : averageBindTime) << ","
+                 << (numIterations <= 1 ? 0 : minBindTime) << "," << (numIterations <= 1 ? 0 : maxBindTime) << ","
+                 << firstEvalTime << "," << (numIterations <= 1 ? 0 : averageEvalTime) << ","
+                 << (numIterations <= 1 ? 0 : minEvalTime) << "," << (numIterations <= 1 ? 0 : maxEvalTime) << ","
+                 << firstLoadWorkingSetMemoryUsage << "," << firstSessionCreationWorkingSetMemoryUsage << ","
+                 << firstBindMemoryUsage << "," << (numIterations <= 1 ? 0 : averageBindMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxBindMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minBindMemoryUsage) << "," << firstEvalMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageEvalMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxEvalMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minEvalMemoryUsage) << "," << firstLoadDedicatedMemoryUsage << ","
+                 << firstSessionCreationDedicatedMemoryUsage << "," << firstBindDedicatedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageBindDedicatedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxBindDedicatedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minBindDedicatedMemoryUsage) << "," << firstEvalDedicatedMemoryUsage
+                 << "," << (numIterations <= 1 ? 0 : averageEvalDedicatedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxEvalDedicatedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minEvalDedicatedMemoryUsage) << "," << firstLoadSharedMemoryUsage << ","
+                 << firstSessionCreationSharedMemoryUsage << "," << firstBindSharedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageBindSharedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxBindSharedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minBindSharedMemoryUsage) << "," << firstEvalSharedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageEvalSharedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxEvalSharedMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minEvalSharedMemoryUsage) << "," << std::endl;
             fout.close();
         }
     }
@@ -904,10 +946,8 @@ public:
     std::vector<double> m_clockBindTimes;
     std::vector<double> m_clockEvalTimes;
 
-    std::wstring getCsvFileNamePerIterationResult()
-    {
-        return m_csvFileNamePerIterationResult;
-    }
+    std::wstring getCsvFileNamePerIterationResult() { return m_csvFileNamePerIterationResult; }
+
 private:
     std::wstring m_csvFileName;
     std::wstring m_csvFileNamePerIterationSummary;

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -1,17 +1,22 @@
-#include "Common.h"
-#include "OutputHelper.h"
-#include "ModelBinding.h"
 #include "BindingUtilities.h"
-#include <filesystem>
-#include <d3d11.h>
-#include <Windows.Graphics.DirectX.Direct3D11.interop.h>
+#include "Common.h"
+#include "ModelBinding.h"
+#include "OutputHelper.h"
 #include "Run.h"
 #include "Scenarios.h"
+#include <Windows.Graphics.DirectX.Direct3D11.interop.h>
+#include <d3d11.h>
+#include <filesystem>
 
-#define THROW_IF_FAILED(hr) { if (FAILED(hr)) throw hresult_error(hr); }
+#define THROW_IF_FAILED(hr)                                                                                            \
+    {                                                                                                                  \
+        if (FAILED(hr))                                                                                                \
+            throw hresult_error(hr);                                                                                   \
+    }
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
-LearningModel LoadModel(const std::wstring &path, bool capturePerf, OutputHelper& output, const CommandLineArgs& args, uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
+LearningModel LoadModel(const std::wstring& path, bool capturePerf, OutputHelper& output, const CommandLineArgs& args,
+                        uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     LearningModel model = nullptr;
     output.PrintLoadingInfo(path);
@@ -50,7 +55,7 @@ std::vector<std::wstring> GetModelsInDirectory(CommandLineArgs& args, OutputHelp
     std::vector<std::wstring> modelPaths;
 
     std::wstring folderPath = args.FolderPath();
-    for (auto & it : std::filesystem::directory_iterator(args.FolderPath()))
+    for (auto& it : std::filesystem::directory_iterator(args.FolderPath()))
     {
         std::string path = it.path().string();
 
@@ -67,13 +72,10 @@ std::vector<std::wstring> GetModelsInDirectory(CommandLineArgs& args, OutputHelp
     return modelPaths;
 }
 
-std::vector<ILearningModelFeatureValue> GenerateInputFeatures(
-    const LearningModel& model,
-    const CommandLineArgs& args,
-    InputBindingType inputBindingType,
-    InputDataType inputDataType,
-    const IDirect3DDevice winrtDevice,
-    uint32_t iterationNum)
+std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningModel& model, const CommandLineArgs& args,
+                                                              InputBindingType inputBindingType,
+                                                              InputDataType inputDataType,
+                                                              const IDirect3DDevice winrtDevice, uint32_t iterationNum)
 {
     std::vector<ILearningModelFeatureValue> inputFeatures;
 
@@ -89,7 +91,8 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(
         }
         else
         {
-            auto imageFeature = BindingUtilities::CreateBindableImage(description, args.ImagePath(), inputBindingType, inputDataType, winrtDevice, args, iterationNum);
+            auto imageFeature = BindingUtilities::CreateBindableImage(description, args.ImagePath(), inputBindingType,
+                                                                      inputDataType, winrtDevice, args, iterationNum);
             inputFeatures.push_back(imageFeature);
         }
     }
@@ -97,7 +100,10 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(
     return inputFeatures;
 }
 
-HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding& context, const std::vector<ILearningModelFeatureValue>& inputFeatures, const CommandLineArgs& args, OutputHelper& output, bool capturePerf, uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
+HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding& context,
+                          const std::vector<ILearningModelFeatureValue>& inputFeatures, const CommandLineArgs& args,
+                          OutputHelper& output, bool capturePerf, uint32_t iterationNum,
+                          Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     assert(model.InputFeatures().Size() == inputFeatures.size());
 
@@ -107,7 +113,8 @@ HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding
 
         if (capturePerf)
         {
-            WINML_PROFILING_START(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::BIND_VALUE_FIRST_RUN : WINML_MODEL_TEST_PERF::BIND_VALUE);
+            WINML_PROFILING_START(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::BIND_VALUE_FIRST_RUN
+                                                              : WINML_MODEL_TEST_PERF::BIND_VALUE);
         }
 
         for (uint32_t i = 0; i < model.InputFeatures().Size(); i++)
@@ -118,7 +125,8 @@ HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding
 
         if (capturePerf)
         {
-            WINML_PROFILING_STOP(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::BIND_VALUE_FIRST_RUN : WINML_MODEL_TEST_PERF::BIND_VALUE);
+            WINML_PROFILING_STOP(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::BIND_VALUE_FIRST_RUN
+                                                             : WINML_MODEL_TEST_PERF::BIND_VALUE);
             if (args.IsPerIterationCapture())
             {
                 output.SaveBindTimes(profiler, iterationNum);
@@ -135,30 +143,25 @@ HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding
     return S_OK;
 }
 
-HRESULT EvaluateModel(
-    LearningModelEvaluationResult& result,
-    const LearningModel& model,
-    const LearningModelBinding& context,
-    LearningModelSession& session,
-    const CommandLineArgs& args,
-    OutputHelper& output,
-    bool capturePerf,
-    uint32_t iterationNum,
-    Profiler<WINML_MODEL_TEST_PERF>& profiler
-)
+HRESULT EvaluateModel(LearningModelEvaluationResult& result, const LearningModel& model,
+                      const LearningModelBinding& context, LearningModelSession& session, const CommandLineArgs& args,
+                      OutputHelper& output, bool capturePerf, uint32_t iterationNum,
+                      Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     try
     {
         if (capturePerf)
         {
-            WINML_PROFILING_START(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::EVAL_MODEL_FIRST_RUN : WINML_MODEL_TEST_PERF::EVAL_MODEL);
+            WINML_PROFILING_START(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::EVAL_MODEL_FIRST_RUN
+                                                              : WINML_MODEL_TEST_PERF::EVAL_MODEL);
         }
 
         result = session.Evaluate(context, L"");
 
         if (capturePerf)
         {
-            WINML_PROFILING_STOP(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::EVAL_MODEL_FIRST_RUN : WINML_MODEL_TEST_PERF::EVAL_MODEL);
+            WINML_PROFILING_STOP(profiler, iterationNum == 0 ? WINML_MODEL_TEST_PERF::EVAL_MODEL_FIRST_RUN
+                                                             : WINML_MODEL_TEST_PERF::EVAL_MODEL);
             if (args.IsPerIterationCapture())
             {
                 output.SaveEvalPerformance(profiler, iterationNum);
@@ -180,19 +183,12 @@ HRESULT EvaluateModel(
     return S_OK;
 }
 
-// Binds and evaluates the user-specified model and outputs success/failure for each step. If the
-// perf flag is used, it will output the CPU, GPU, and wall-clock time for each step to the
-// command-line and to a CSV file.
-HRESULT EvaluateModel(
-    const LearningModel& model,
-    const CommandLineArgs& args,
-    OutputHelper& output,
-    DeviceType deviceType,
-    InputBindingType inputBindingType,
-    InputDataType inputDataType,
-    DeviceCreationLocation deviceCreationLocation,
-    Profiler<WINML_MODEL_TEST_PERF>& profiler
-)
+// Binds and evaluates the user-specified model and outputs success/failure for
+// each step. If the perf flag is used, it will output the CPU, GPU, and
+// wall-clock time for each step to the command-line and to a CSV file.
+HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, OutputHelper& output,
+                      DeviceType deviceType, InputBindingType inputBindingType, InputDataType inputDataType,
+                      DeviceCreationLocation deviceCreationLocation, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     if (model == nullptr)
     {
@@ -204,8 +200,7 @@ HRESULT EvaluateModel(
 
     try
     {
-        if (deviceCreationLocation == DeviceCreationLocation::ClientCode
-            && deviceType != DeviceType::CPU)
+        if (deviceCreationLocation == DeviceCreationLocation::ClientCode && deviceType != DeviceType::CPU)
         {
             // Enumerate Adapters to pick the requested one.
             com_ptr<IDXGIFactory6> factory;
@@ -216,23 +211,30 @@ HRESULT EvaluateModel(
             switch (deviceType)
             {
             case DeviceType::DefaultGPU:
-                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_UNSPECIFIED, __uuidof(IDXGIAdapter), adapter.put_void());
+                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_UNSPECIFIED, __uuidof(IDXGIAdapter),
+                                                         adapter.put_void());
                 break;
             case DeviceType::MinPowerGPU:
-                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_MINIMUM_POWER, __uuidof(IDXGIAdapter), adapter.put_void());
+                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_MINIMUM_POWER, __uuidof(IDXGIAdapter),
+                                                         adapter.put_void());
                 break;
             case DeviceType::HighPerfGPU:
-                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, __uuidof(IDXGIAdapter), adapter.put_void());
+                hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+                                                         __uuidof(IDXGIAdapter), adapter.put_void());
                 break;
             default:
                 throw hresult(E_INVALIDARG);
             }
             THROW_IF_FAILED(hr);
 
-            // Creating the device on the client and using it to create the video frame and initialize the session makes sure that everything is on
-            // the same device. This usually avoids an expensive cross-device and cross-videoframe copy via the VideoFrame pipeline.
+            // Creating the device on the client and using it to create the
+            // video frame and initialize the session makes sure that everything
+            // is on the same device. This usually avoids an expensive
+            // cross-device and cross-videoframe copy via the VideoFrame
+            // pipeline.
             com_ptr<ID3D11Device> d3d11Device;
-            hr = D3D11CreateDevice(adapter.get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0, D3D11_SDK_VERSION, d3d11Device.put(), nullptr, nullptr);
+            hr = D3D11CreateDevice(adapter.get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                                   nullptr, 0, D3D11_SDK_VERSION, d3d11Device.put(), nullptr, nullptr);
             THROW_IF_FAILED(hr);
 
             com_ptr<IDXGIDevice> dxgiDevice;
@@ -280,7 +282,7 @@ HRESULT EvaluateModel(
 
     if (args.IsEvaluationDebugOutputEnabled())
     {
-        // Enables trace log output. 
+        // Enables trace log output.
         session.EvaluationProperties().Insert(L"EnableDebugOutput", nullptr);
     }
 
@@ -308,32 +310,39 @@ HRESULT EvaluateModel(
             return hr.code();
         }
 
-        HRESULT bindInputResult = BindInputFeatures(model, context, inputFeatures, args, output, captureIterationPerf, i, profiler);
+        HRESULT bindInputResult =
+            BindInputFeatures(model, context, inputFeatures, args, output, captureIterationPerf, i, profiler);
 
         if (FAILED(bindInputResult))
         {
-            output.PrintBindingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation, "[FAILED]");
+            output.PrintBindingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation,
+                                    "[FAILED]");
             return bindInputResult;
         }
         else if (!args.TerseOutput() || i == 0)
         {
-            output.PrintBindingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation, "[SUCCESS]");
+            output.PrintBindingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation,
+                                    "[SUCCESS]");
         }
 
         LearningModelEvaluationResult result = nullptr;
-        HRESULT evalResult = EvaluateModel(result, model, context, session, args, output, captureIterationPerf, i, profiler);
+        HRESULT evalResult =
+            EvaluateModel(result, model, context, session, args, output, captureIterationPerf, i, profiler);
 
         if (FAILED(evalResult))
         {
-            output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation, "[FAILED]");
+            output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation,
+                                       "[FAILED]");
             return evalResult;
         }
         else if (!args.TerseOutput() || i == 0)
         {
-            output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation, "[SUCCESS]");
+            output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation,
+                                       "[SUCCESS]");
             if (args.TerseOutput() && args.NumIterations() > 1)
             {
-                printf("Binding and Evaluating %d more time%s...", args.NumIterations()-1, (args.NumIterations() == 2 ? "" : "s"));
+                printf("Binding and Evaluating %d more time%s...", args.NumIterations() - 1,
+                       (args.NumIterations() == 2 ? "" : "s"));
                 completionString = "[SUCCESS]\n";
             }
         }
@@ -352,16 +361,11 @@ HRESULT EvaluateModel(
     return S_OK;
 }
 
-HRESULT EvaluateModels(
-    const std::vector<std::wstring>& modelPaths,
-    const std::vector<DeviceType>& deviceTypes,
-    const std::vector<InputBindingType>& inputBindingTypes,
-    const std::vector<InputDataType>& inputDataTypes,
-    const std::vector<DeviceCreationLocation> deviceCreationLocations,
-    const CommandLineArgs& args,
-    OutputHelper& output,
-    Profiler<WINML_MODEL_TEST_PERF>& profiler
-)
+HRESULT EvaluateModels(const std::vector<std::wstring>& modelPaths, const std::vector<DeviceType>& deviceTypes,
+                       const std::vector<InputBindingType>& inputBindingTypes,
+                       const std::vector<InputDataType>& inputDataTypes,
+                       const std::vector<DeviceCreationLocation> deviceCreationLocations, const CommandLineArgs& args,
+                       OutputHelper& output, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     output.PrintHardwareInfo();
 
@@ -371,7 +375,8 @@ HRESULT EvaluateModels(
 
         try
         {
-            model = LoadModel(path, args.IsPerformanceCapture() || args.IsPerIterationCapture(), output, args, 0, profiler);
+            model =
+                LoadModel(path, args.IsPerformanceCapture() || args.IsPerIterationCapture(), output, args, 0, profiler);
         }
         catch (hresult_error hr)
         {
@@ -385,34 +390,40 @@ HRESULT EvaluateModels(
         // Map and Sequence bindings are not supported yet
         if (!tensorDescriptor)
         {
-            std::wcout << L"Model: " + path + L" has an input type that isn't supported by WinMLRunner yet." << std::endl;
+            std::wcout << L"Model: " + path +
+                              L" has an input type that isn't supported by "
+                              L"WinMLRunner yet."
+                       << std::endl;
             continue;
         }
 
-        for (const auto &deviceType : deviceTypes)
+        for (const auto& deviceType : deviceTypes)
         {
-            for (const auto &inputBindingType : inputBindingTypes)
+            for (const auto& inputBindingType : inputBindingTypes)
             {
-                for (const auto &inputDataType : inputDataTypes)
+                for (const auto& inputDataType : inputDataTypes)
                 {
-                    for (const auto &deviceCreationLocation : deviceCreationLocations)
+                    for (const auto& deviceCreationLocation : deviceCreationLocations)
                     {
                         if (args.IsPerformanceCapture() || args.IsPerIterationCapture())
                         {
-                            // Resets all values from profiler for bind and evaluate.
+                            // Resets all values from profiler for bind and
+                            // evaluate.
                             profiler.Reset(WINML_MODEL_TEST_PERF::BIND_VALUE, WINML_MODEL_TEST_PERF::COUNT);
                         }
 
                         if (inputDataType != InputDataType::Tensor)
                         {
-                            // Currently GPU binding only work with 4D tensors and RGBA/BGRA images
+                            // Currently GPU binding only work with 4D tensors
+                            // and RGBA/BGRA images
                             if (tensorDescriptor.Shape().Size() != 4 || tensorDescriptor.Shape().GetAt(1) != 3)
                             {
                                 continue;
                             }
                         }
 
-                        HRESULT evalHResult = EvaluateModel(model, args, output, deviceType, inputBindingType, inputDataType, deviceCreationLocation, profiler);
+                        HRESULT evalHResult = EvaluateModel(model, args, output, deviceType, inputBindingType,
+                                                            inputDataType, deviceCreationLocation, profiler);
 
                         if (FAILED(evalHResult))
                         {
@@ -421,22 +432,20 @@ HRESULT EvaluateModels(
 
                         if (args.IsPerformanceCapture())
                         {
-                            output.PrintResults(profiler, args.NumIterations(), deviceType, inputBindingType, inputDataType, deviceCreationLocation, args.IsPerformanceConsoleOutputVerbose());
+                            output.PrintResults(profiler, args.NumIterations(), deviceType, inputBindingType,
+                                                inputDataType, deviceCreationLocation,
+                                                args.IsPerformanceConsoleOutputVerbose());
                             if (args.IsOutputPerf())
                             {
                                 std::string deviceTypeStringified = TypeHelper::Stringify(deviceType);
                                 std::string inputDataTypeStringified = TypeHelper::Stringify(inputDataType);
                                 std::string inputBindingTypeStringified = TypeHelper::Stringify(inputBindingType);
-                                std::string deviceCreationLocationStringified = TypeHelper::Stringify(deviceCreationLocation);
-                                output.WritePerformanceDataToCSV(
-                                    profiler,
-                                    args.NumIterations(),
-                                    path,
-                                    deviceTypeStringified,
-                                    inputDataTypeStringified,
-                                    inputBindingTypeStringified,
-                                    deviceCreationLocationStringified
-                                );
+                                std::string deviceCreationLocationStringified =
+                                    TypeHelper::Stringify(deviceCreationLocation);
+                                output.WritePerformanceDataToCSV(profiler, args.NumIterations(), path,
+                                                                 deviceTypeStringified, inputDataTypeStringified,
+                                                                 inputBindingTypeStringified,
+                                                                 deviceCreationLocationStringified);
                             }
                         }
                     }
@@ -539,8 +548,8 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
     winrt::init_apartment();
     OutputHelper output(args.NumIterations());
 
-    // Profiler is a wrapper class that captures and stores timing and memory usage data on the
-    // CPU and GPU.
+    // Profiler is a wrapper class that captures and stores timing and memory
+    // usage data on the CPU and GPU.
     profiler.Enable();
 
     if (!args.OutputPath().empty())
@@ -564,13 +573,17 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
         std::vector<InputBindingType> inputBindingTypes = FetchInputBindingTypes(args);
         std::vector<InputDataType> inputDataTypes = FetchInputDataTypes(args);
         std::vector<DeviceCreationLocation> deviceCreationLocations = FetchDeviceCreationLocations(args);
-        std::vector<std::wstring> modelPaths = args.ModelPath().empty() ? GetModelsInDirectory(args, &output) : std::vector<std::wstring>(1, args.ModelPath());
+        std::vector<std::wstring> modelPaths = args.ModelPath().empty()
+                                                   ? GetModelsInDirectory(args, &output)
+                                                   : std::vector<std::wstring>(1, args.ModelPath());
 
-        if (args.IsConcurrentLoad()) {
+        if (args.IsConcurrentLoad())
+        {
             ConcurrentLoadModel(modelPaths, args.NumThreads(), args.ThreadInterval(), true);
             return 0;
         }
-        return EvaluateModels(modelPaths, deviceTypes, inputBindingTypes, inputDataTypes, deviceCreationLocations, args, output, profiler);
+        return EvaluateModels(modelPaths, deviceTypes, inputBindingTypes, inputDataTypes, deviceCreationLocations, args,
+                              output, profiler);
     }
 
     return 0;

--- a/Tools/WinMLRunner/src/Run.h
+++ b/Tools/WinMLRunner/src/Run.h
@@ -1,3 +1,3 @@
 #include "CommandLineArgs.h"
 
-int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler);
+int run(CommandLineArgs &args, Profiler<WINML_MODEL_TEST_PERF> &profiler);

--- a/Tools/WinMLRunner/src/Scenarios.h
+++ b/Tools/WinMLRunner/src/Scenarios.h
@@ -5,5 +5,5 @@
 // load a model in a multi-threaded environment with num_threads number of
 // threads Each thread will load a model once, with interval in milliseconds for
 // each thread tasks
-void ConcurrentLoadModel(const std::vector<std::wstring> &paths, unsigned num_threads,
-                         unsigned interval_milliseconds, bool print_info);
+void ConcurrentLoadModel(const std::vector<std::wstring> &paths, unsigned num_threads, unsigned interval_milliseconds,
+                         bool print_info);

--- a/Tools/WinMLRunner/src/ThreadPool.cpp
+++ b/Tools/WinMLRunner/src/ThreadPool.cpp
@@ -1,20 +1,26 @@
 #include "ThreadPool.h"
 #include <ctime>
 
-ThreadPool::ThreadPool(unsigned int initial_pool_size): m_threads(), m_destruct_pool(false) {
-    for (unsigned int i = 0; i < initial_pool_size; i++) {
+ThreadPool::ThreadPool(unsigned int initial_pool_size) : m_threads(), m_destruct_pool(false)
+{
+    for (unsigned int i = 0; i < initial_pool_size; i++)
+    {
         m_threads.emplace_back([this]() {
-            while (true) {
+            while (true)
+            {
                 std::unique_lock<std::mutex> lock(m_mutex);
-                // thread listening for event and acquire lock if event triggered
+                // thread listening for event and acquire lock if event
+                // triggered
                 m_cond_var.wait(lock, [this] { return m_destruct_pool || !m_work_queue.empty(); });
-                if (!m_work_queue.empty()) {
+                if (!m_work_queue.empty())
+                {
                     auto work = m_work_queue.front();
                     m_work_queue.pop();
                     lock.unlock();
                     work();
                 }
-                else {
+                else
+                {
                     // Work queue is empty but lock acquired
                     // This means we are destructing the pool
                     break;
@@ -24,10 +30,12 @@ ThreadPool::ThreadPool(unsigned int initial_pool_size): m_threads(), m_destruct_
     }
 }
 
-ThreadPool::~ThreadPool() {
+ThreadPool::~ThreadPool()
+{
     m_destruct_pool = true;
     m_cond_var.notify_all(); // notify destruction to threads
-    for (auto &thread : m_threads) {
+    for (auto& thread : m_threads)
+    {
         thread.join();
     }
 }

--- a/Tools/WinMLRunner/src/ThreadPool.h
+++ b/Tools/WinMLRunner/src/ThreadPool.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <vector>
-#include <thread>
-#include <queue>
-#include <mutex>
 #include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
 
-class ThreadPool {
+class ThreadPool
+{
 private:
     std::condition_variable m_cond_var;
     bool m_destruct_pool;
@@ -17,8 +18,9 @@ private:
 public:
     ThreadPool(unsigned int initial_pool_size);
     ~ThreadPool();
-    template <typename F, typename...Args>
-    inline auto SubmitWork(F &&f, Args&&... args) -> std::future<decltype(f(args...))> {
+    template <typename F, typename... Args>
+    inline auto SubmitWork(F&& f, Args&&... args) -> std::future<decltype(f(args...))>
+    {
         auto func = std::bind(std::forward<F>(f), std::forward<Args>(args)...);
         auto task = std::make_shared<std::packaged_task<decltype(f(args...))()>>(func);
         {

--- a/Tools/WinMLRunner/src/TimerHelper.h
+++ b/Tools/WinMLRunner/src/TimerHelper.h
@@ -1,20 +1,20 @@
 #pragma once
 
 #include "Common.h"
-#include <windows.h>
 #include <cmath>
+#include <windows.h>
 #ifndef DISABLE_GPU_COUNTERS
 #include <Pdh.h>
 #include <PdhMsg.h>
 #endif
 #include <psapi.h>
 
-
 #define TIMER_SLOT_SIZE (128)
-#define CONVERT_100NS_TO_SECOND(x) ((x) * 0.0000001)
-#define BYTE_TO_MB(x) ((x)/(1024.0*1024.0))
+#define CONVERT_100NS_TO_SECOND(x) ((x)*0.0000001)
+#define BYTE_TO_MB(x) ((x) / (1024.0 * 1024.0))
 
-// A stopwatch to measure the time passed (in milliseconds ) between current Stop call and the closest Start call that has been called before.
+// A stopwatch to measure the time passed (in milliseconds ) between current Stop call and the closest Start call that
+// has been called before.
 class Timer
 {
 public:
@@ -42,23 +42,22 @@ private:
 class CpuPerfCounter
 {
 public:
-    CpuPerfCounter()
-    {
-        Reset();
-    }
+    CpuPerfCounter() { Reset(); }
 
     ~CpuPerfCounter() {}
 
     void Reset()
     {
-        SYSTEM_INFO sysInfo = { 0 };
+        SYSTEM_INFO sysInfo = {0};
         GetSystemInfo(&sysInfo);
 
-        m_startKernelTime = { 0 };
-        m_startUserTime = { 0 };
+        m_startKernelTime = {0};
+        m_startUserTime = {0};
         m_numProcessors = sysInfo.dwNumberOfProcessors;
-        m_procHandle = GetCurrentProcess();;
-        m_pid = GetCurrentProcessId();;
+        m_procHandle = GetCurrentProcess();
+        ;
+        m_pid = GetCurrentProcessId();
+        ;
         m_previousStartCallFailed = true;
         m_processTime = 0;
         m_startPageFaultCount = 0;
@@ -78,7 +77,8 @@ public:
         FILETIME ftIgnore, ftKernel, ftUser;
 
         if (!GetProcessTimes(m_procHandle, &ftIgnore, &ftIgnore, &ftKernel, &ftUser) ||
-            !GetProcessMemoryCounters(m_pid, m_startPageFaultCount, m_startPagefileUsage, m_startPeakPagefileUsage, m_startWorkingSetSize, m_startPeakWorkingSetSize))
+            !GetProcessMemoryCounters(m_pid, m_startPageFaultCount, m_startPagefileUsage, m_startPeakPagefileUsage,
+                                      m_startWorkingSetSize, m_startPeakWorkingSetSize))
         {
             m_previousStartCallFailed = true;
         }
@@ -94,29 +94,32 @@ public:
     {
         FILETIME ftIgnore, ftKernel, ftUser;
         ULARGE_INTEGER stopKernelTime, stopUserTime;
-        ULONG  stopPageFaultCount = 0;
+        ULONG stopPageFaultCount = 0;
         SIZE_T stopPagefileUsage = 0;
         SIZE_T stopPeakPagefileUsage = 0;
         SIZE_T stopWorkingSetSize = 0;
         SIZE_T stopPeakWorkingSetSize = 0;
 
-        if (m_previousStartCallFailed ||
-            m_numProcessors == 0 ||
+        if (m_previousStartCallFailed || m_numProcessors == 0 ||
             !GetProcessTimes(m_procHandle, &ftIgnore, &ftIgnore, &ftKernel, &ftUser) ||
-            !GetProcessMemoryCounters(m_pid, stopPageFaultCount, stopPagefileUsage, stopPeakPagefileUsage, stopWorkingSetSize, stopPeakWorkingSetSize))
+            !GetProcessMemoryCounters(m_pid, stopPageFaultCount, stopPagefileUsage, stopPeakPagefileUsage,
+                                      stopWorkingSetSize, stopPeakWorkingSetSize))
         {
             return;
         }
 
         memcpy(&stopKernelTime, &ftKernel, sizeof(FILETIME));
         memcpy(&stopUserTime, &ftUser, sizeof(FILETIME));
-        m_processTime = CONVERT_100NS_TO_SECOND((stopKernelTime.QuadPart - m_startKernelTime.QuadPart) + (stopUserTime.QuadPart - m_startUserTime.QuadPart)) / m_numProcessors;
+        m_processTime = CONVERT_100NS_TO_SECOND((stopKernelTime.QuadPart - m_startKernelTime.QuadPart) +
+                                                (stopUserTime.QuadPart - m_startUserTime.QuadPart)) /
+                        m_numProcessors;
 
         m_deltaPageFaultCount = stopPageFaultCount - m_startPageFaultCount;
         m_deltaPagefileUsage = (double)BYTE_TO_MB((double)stopPagefileUsage - (double)m_startPagefileUsage);
         m_deltaPeakPagefileUsage = (double)BYTE_TO_MB((double)stopPeakPagefileUsage - (double)m_startPeakPagefileUsage);
         m_deltaWorkingSetSize = (double)BYTE_TO_MB((double)stopWorkingSetSize - (double)m_startWorkingSetSize);
-        m_deltaPeakWorkingSetSize = (double)BYTE_TO_MB((double)stopPeakWorkingSetSize - (double)m_startPeakWorkingSetSize);
+        m_deltaPeakWorkingSetSize =
+            (double)BYTE_TO_MB((double)stopPeakWorkingSetSize - (double)m_startPeakWorkingSetSize);
     }
 
     double GetProcessTime() { return m_processTime; }
@@ -128,9 +131,8 @@ public:
     double GetStartWorkingSet() { return (double)BYTE_TO_MB((double)m_startWorkingSetSize); }
 
 private:
-
-    bool GetProcessMemoryCounters(DWORD pid, ULONG& pageFaultCount, SIZE_T& pageFileUsage, SIZE_T& peakPageFileUsage,
-        SIZE_T& workingSetSize, SIZE_T& peakWorkingSetSize)
+    bool GetProcessMemoryCounters(DWORD pid, ULONG &pageFaultCount, SIZE_T &pageFileUsage, SIZE_T &peakPageFileUsage,
+                                  SIZE_T &workingSetSize, SIZE_T &peakWorkingSetSize)
     {
         HANDLE hProcess = NULL;
 
@@ -138,7 +140,7 @@ private:
         if (NULL == hProcess)
             return false;
 
-        PROCESS_MEMORY_COUNTERS pmc = { 0 };
+        PROCESS_MEMORY_COUNTERS pmc = {0};
 
         bool result = GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc));
         if (result)
@@ -161,32 +163,27 @@ private:
     HANDLE m_procHandle;
     DWORD m_pid;
     bool m_previousStartCallFailed;
-    double m_processTime;         // in second
+    double m_processTime; // in second
     ULONG m_startPageFaultCount;
-    SIZE_T m_startPagefileUsage;       // in byte
-    SIZE_T m_startPeakPagefileUsage;   // in byte
-    SIZE_T m_startWorkingSetSize;      // in byte
-    SIZE_T m_startPeakWorkingSetSize;  // in byte
+    SIZE_T m_startPagefileUsage;      // in byte
+    SIZE_T m_startPeakPagefileUsage;  // in byte
+    SIZE_T m_startWorkingSetSize;     // in byte
+    SIZE_T m_startPeakWorkingSetSize; // in byte
     ULONG m_deltaPageFaultCount;
-    double m_deltaPagefileUsage;       // in MByte
-    double m_deltaPeakPagefileUsage;   // in MByte
-    double m_deltaWorkingSetSize;      // in MByte
-    double m_deltaPeakWorkingSetSize;  // in MByte
+    double m_deltaPagefileUsage;      // in MByte
+    double m_deltaPeakPagefileUsage;  // in MByte
+    double m_deltaWorkingSetSize;     // in MByte
+    double m_deltaPeakWorkingSetSize; // in MByte
 };
 #ifndef DISABLE_GPU_COUNTERS
 
 class GpuPerfCounter
 {
 public:
-    GpuPerfCounter() :
-        m_hPDH(NULL),
-        m_pfnPdhOpenQuery(NULL),
-        m_pfnPdhAddCounter(NULL),
-        m_pfnPdhCollectQueryData(NULL),
-        m_pfnPdhGetFormattedCounterArray(NULL),
-        m_pfnPdhGetFormattedCounterValue(NULL),
-        m_pfnPdhCloseQuery(NULL),
-        m_query(NULL)
+    GpuPerfCounter()
+        : m_hPDH(NULL), m_pfnPdhOpenQuery(NULL), m_pfnPdhAddCounter(NULL), m_pfnPdhCollectQueryData(NULL),
+          m_pfnPdhGetFormattedCounterArray(NULL), m_pfnPdhGetFormattedCounterValue(NULL), m_pfnPdhCloseQuery(NULL),
+          m_query(NULL)
     {
         //#ifdef DISABLE_LOADLIBRARY
         m_hPDH = LoadLibraryEx(L"pdh.dll", NULL, 0);
@@ -196,8 +193,10 @@ public:
             m_pfnPdhOpenQuery = (PFNPdhOpenQuery)GetProcAddress(m_hPDH, "PdhOpenQueryW");
             m_pfnPdhAddCounter = (PFNPdhAddCounter)GetProcAddress(m_hPDH, "PdhAddCounterW");
             m_pfnPdhCollectQueryData = (PFNPdhCollectQueryData)GetProcAddress(m_hPDH, "PdhCollectQueryData");
-            m_pfnPdhGetFormattedCounterArray = (PFNPdhGetFormattedCounterArray)GetProcAddress(m_hPDH, "PdhGetFormattedCounterArrayW");
-            m_pfnPdhGetFormattedCounterValue = (PFNPdhGetFormattedCounterValue)GetProcAddress(m_hPDH, "PdhGetFormattedCounterValue");
+            m_pfnPdhGetFormattedCounterArray =
+                (PFNPdhGetFormattedCounterArray)GetProcAddress(m_hPDH, "PdhGetFormattedCounterArrayW");
+            m_pfnPdhGetFormattedCounterValue =
+                (PFNPdhGetFormattedCounterValue)GetProcAddress(m_hPDH, "PdhGetFormattedCounterValue");
             m_pfnPdhCloseQuery = (PFNPdhCloseQuery)GetProcAddress(m_hPDH, "PdhCloseQuery");
         }
 
@@ -234,7 +233,8 @@ public:
         gpuSharedMemQueryStr.replace(gpuSharedMemQueryStr.find('*'), 1, pidStr);
 
         // Open query
-        if (m_query) CloseQuery(m_query);
+        if (m_query)
+            CloseQuery(m_query);
         m_query = NULL;
         OpenQuery(NULL, NULL, &m_query);
         AddCounter(m_query, gpuUsageQueryStr.c_str(), NULL, &m_gpuUsageCounter);
@@ -252,17 +252,23 @@ public:
         CollectQueryData(m_query);
 
         // Gpu dedicated ememory
-        status = GetFormattedCounterValue(m_gpuDedicatedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuDedicatedMemUsageCounterValue);
-        m_startGpuDedicatedMemory = (ERROR_SUCCESS == status) ? (double)BYTE_TO_MB(gpuDedicatedMemUsageCounterValue.largeValue) : m_startGpuDedicatedMemory;
+        status = GetFormattedCounterValue(m_gpuDedicatedMemUsageCounter, PDH_FMT_LARGE, NULL,
+                                          &gpuDedicatedMemUsageCounterValue);
+        m_startGpuDedicatedMemory = (ERROR_SUCCESS == status)
+                                        ? (double)BYTE_TO_MB(gpuDedicatedMemUsageCounterValue.largeValue)
+                                        : m_startGpuDedicatedMemory;
 
         // Gpu shared ememory
-        status = GetFormattedCounterValue(m_gpuSharedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuSharedMemUsageCounterValue);
-        m_startGpuSharedMemory = (ERROR_SUCCESS == status) ? (double)BYTE_TO_MB(gpuSharedMemUsageCounterValue.largeValue) : m_startGpuSharedMemory;
+        status =
+            GetFormattedCounterValue(m_gpuSharedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuSharedMemUsageCounterValue);
+        m_startGpuSharedMemory = (ERROR_SUCCESS == status)
+                                     ? (double)BYTE_TO_MB(gpuSharedMemUsageCounterValue.largeValue)
+                                     : m_startGpuSharedMemory;
     }
 
     void Stop()
     {
-        PDH_FMT_COUNTERVALUE_ITEM* gpuUsageCounterValue = nullptr;
+        PDH_FMT_COUNTERVALUE_ITEM *gpuUsageCounterValue = nullptr;
         PDH_FMT_COUNTERVALUE gpuDedicatedMemUsageCounterValue = {};
         PDH_FMT_COUNTERVALUE gpuSharedMemUsageCounterValue = {};
         DWORD bufferSize = 0;
@@ -277,20 +283,24 @@ public:
         if (S_OK != status && PDH_NO_DATA != status)
             return;
 
-        status = GetFormattedCounterArray(m_gpuUsageCounter, PDH_FMT_DOUBLE, &bufferSize, &itemCount, gpuUsageCounterValue);
+        status =
+            GetFormattedCounterArray(m_gpuUsageCounter, PDH_FMT_DOUBLE, &bufferSize, &itemCount, gpuUsageCounterValue);
         if (PDH_MORE_DATA != status)
             return;
 
         gpuUsageCounterValue = (PDH_FMT_COUNTERVALUE_ITEM *)malloc(bufferSize);
         if (gpuUsageCounterValue != nullptr)
         {
-            status = GetFormattedCounterArray(m_gpuUsageCounter, PDH_FMT_DOUBLE, &bufferSize, &itemCount, gpuUsageCounterValue);
+            status = GetFormattedCounterArray(m_gpuUsageCounter, PDH_FMT_DOUBLE, &bufferSize, &itemCount,
+                                              gpuUsageCounterValue);
             if (ERROR_SUCCESS == status)
             {
                 double maxValue = 0;
                 for (size_t i = 0; i < itemCount; ++i)
                 {
-                    maxValue = (gpuUsageCounterValue[i].FmtValue.doubleValue > maxValue) ? gpuUsageCounterValue[i].FmtValue.doubleValue : maxValue;
+                    maxValue = (gpuUsageCounterValue[i].FmtValue.doubleValue > maxValue)
+                                   ? gpuUsageCounterValue[i].FmtValue.doubleValue
+                                   : maxValue;
                 }
                 m_gpuUsage = maxValue;
             }
@@ -301,17 +311,19 @@ public:
         bufferSize = 0;
         itemCount = 0;
 
-        double stopGpuDedicatedMemory;  // in MB
-        double stopGpuSharedMemory;     // in MB
+        double stopGpuDedicatedMemory; // in MB
+        double stopGpuSharedMemory;    // in MB
 
-        status = GetFormattedCounterValue(m_gpuDedicatedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuDedicatedMemUsageCounterValue);
+        status = GetFormattedCounterValue(m_gpuDedicatedMemUsageCounter, PDH_FMT_LARGE, NULL,
+                                          &gpuDedicatedMemUsageCounterValue);
         if (ERROR_SUCCESS == status)
         {
             stopGpuDedicatedMemory = (double)BYTE_TO_MB(gpuDedicatedMemUsageCounterValue.largeValue);
             m_deltaGpuDedicatedMemory = stopGpuDedicatedMemory - m_startGpuDedicatedMemory;
         }
 
-        status = GetFormattedCounterValue(m_gpuSharedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuSharedMemUsageCounterValue);
+        status =
+            GetFormattedCounterValue(m_gpuSharedMemUsageCounter, PDH_FMT_LARGE, NULL, &gpuSharedMemUsageCounterValue);
         if (ERROR_SUCCESS == status)
         {
             stopGpuSharedMemory = (double)BYTE_TO_MB(gpuSharedMemUsageCounterValue.largeValue);
@@ -326,32 +338,47 @@ public:
 
 private:
     // Pdh function prototypes
-    typedef PDH_STATUS(WINAPI *PFNPdhOpenQuery)(_In_opt_ LPCWSTR szDataSource, _In_ DWORD_PTR dwUserData, _Out_ PDH_HQUERY * phQuery);
-    typedef PDH_STATUS(WINAPI *PFNPdhAddCounter)(_In_ PDH_HQUERY hQuery, _In_ LPCWSTR szFullCounterPath, _In_ DWORD_PTR dwUserData, _Out_ PDH_HCOUNTER * phCounter);
+    typedef PDH_STATUS(WINAPI *PFNPdhOpenQuery)(_In_opt_ LPCWSTR szDataSource, _In_ DWORD_PTR dwUserData,
+                                                _Out_ PDH_HQUERY *phQuery);
+    typedef PDH_STATUS(WINAPI *PFNPdhAddCounter)(_In_ PDH_HQUERY hQuery, _In_ LPCWSTR szFullCounterPath,
+                                                 _In_ DWORD_PTR dwUserData, _Out_ PDH_HCOUNTER *phCounter);
     typedef PDH_STATUS(WINAPI *PFNPdhCollectQueryData)(_Inout_ PDH_HQUERY hQuery);
-    typedef PDH_STATUS(WINAPI *PFNPdhGetFormattedCounterArray)(_In_ PDH_HCOUNTER hCounter, _In_ DWORD dwFormat, _Inout_ LPDWORD lpdwBufferSize, _Out_ LPDWORD lpdwItemCount, _Out_writes_bytes_opt_(*lpdwBufferSize) PPDH_FMT_COUNTERVALUE_ITEM_W ItemBuffer);
-    typedef PDH_STATUS(WINAPI *PFNPdhGetFormattedCounterValue)(_In_ PDH_HCOUNTER hCounter, _In_ DWORD dwFormat, _Out_opt_ LPDWORD lpdwType, _Out_ PPDH_FMT_COUNTERVALUE pValue);
+    typedef PDH_STATUS(WINAPI *PFNPdhGetFormattedCounterArray)(_In_ PDH_HCOUNTER hCounter, _In_ DWORD dwFormat,
+                                                               _Inout_ LPDWORD lpdwBufferSize,
+                                                               _Out_ LPDWORD lpdwItemCount,
+                                                               _Out_writes_bytes_opt_(*lpdwBufferSize)
+                                                                   PPDH_FMT_COUNTERVALUE_ITEM_W ItemBuffer);
+    typedef PDH_STATUS(WINAPI *PFNPdhGetFormattedCounterValue)(_In_ PDH_HCOUNTER hCounter, _In_ DWORD dwFormat,
+                                                               _Out_opt_ LPDWORD lpdwType,
+                                                               _Out_ PPDH_FMT_COUNTERVALUE pValue);
     typedef PDH_STATUS(WINAPI *PFNPdhCloseQuery)(_Inout_ PDH_HQUERY hQuery);
 
-    PDH_STATUS OpenQuery(LPCWSTR szDataSource, DWORD_PTR dwUserData, PDH_HQUERY * phQuery)
+    PDH_STATUS OpenQuery(LPCWSTR szDataSource, DWORD_PTR dwUserData, PDH_HQUERY *phQuery)
     {
         return (m_pfnPdhOpenQuery) ? m_pfnPdhOpenQuery(szDataSource, dwUserData, phQuery) : ERROR_MOD_NOT_FOUND;
     }
-    PDH_STATUS AddCounter(PDH_HQUERY hQuery, LPCWSTR szFullCounterPath, DWORD_PTR dwUserData, PDH_HCOUNTER * phCounter)
+    PDH_STATUS AddCounter(PDH_HQUERY hQuery, LPCWSTR szFullCounterPath, DWORD_PTR dwUserData, PDH_HCOUNTER *phCounter)
     {
-        return (m_pfnPdhAddCounter) ? m_pfnPdhAddCounter(hQuery, szFullCounterPath, dwUserData, phCounter) : ERROR_MOD_NOT_FOUND;
+        return (m_pfnPdhAddCounter) ? m_pfnPdhAddCounter(hQuery, szFullCounterPath, dwUserData, phCounter)
+                                    : ERROR_MOD_NOT_FOUND;
     }
     PDH_STATUS CollectQueryData(PDH_HQUERY hQuery)
     {
         return (m_pfnPdhCollectQueryData) ? m_pfnPdhCollectQueryData(hQuery) : ERROR_MOD_NOT_FOUND;
     }
-    PDH_STATUS GetFormattedCounterArray(PDH_HCOUNTER hCounter, DWORD dwFormat, LPDWORD lpdwBufferSize, LPDWORD lpdwItemCount, PPDH_FMT_COUNTERVALUE_ITEM_W ItemBuffer)
+    PDH_STATUS GetFormattedCounterArray(PDH_HCOUNTER hCounter, DWORD dwFormat, LPDWORD lpdwBufferSize,
+                                        LPDWORD lpdwItemCount, PPDH_FMT_COUNTERVALUE_ITEM_W ItemBuffer)
     {
-        return (m_pfnPdhGetFormattedCounterArray) ? m_pfnPdhGetFormattedCounterArray(hCounter, dwFormat, lpdwBufferSize, lpdwItemCount, ItemBuffer) : ERROR_MOD_NOT_FOUND;
+        return (m_pfnPdhGetFormattedCounterArray)
+                   ? m_pfnPdhGetFormattedCounterArray(hCounter, dwFormat, lpdwBufferSize, lpdwItemCount, ItemBuffer)
+                   : ERROR_MOD_NOT_FOUND;
     }
-    PDH_STATUS GetFormattedCounterValue(PDH_HCOUNTER hCounter, DWORD dwFormat, LPDWORD lpdwType, PPDH_FMT_COUNTERVALUE pValue)
+    PDH_STATUS GetFormattedCounterValue(PDH_HCOUNTER hCounter, DWORD dwFormat, LPDWORD lpdwType,
+                                        PPDH_FMT_COUNTERVALUE pValue)
     {
-        return (m_pfnPdhGetFormattedCounterValue) ? m_pfnPdhGetFormattedCounterValue(hCounter, dwFormat, lpdwType, pValue) : ERROR_MOD_NOT_FOUND;
+        return (m_pfnPdhGetFormattedCounterValue)
+                   ? m_pfnPdhGetFormattedCounterValue(hCounter, dwFormat, lpdwType, pValue)
+                   : ERROR_MOD_NOT_FOUND;
     }
     PDH_STATUS CloseQuery(PDH_HQUERY hQuery)
     {
@@ -374,10 +401,10 @@ private:
     DWORD m_pid;
     // Data
     double m_gpuUsage;
-    double m_startGpuDedicatedMemory;  // in MB
-    double m_startGpuSharedMemory;     // in MB
-    double m_deltaGpuDedicatedMemory;  // in MB
-    double m_deltaGpuSharedMemory;     // in MB
+    double m_startGpuDedicatedMemory; // in MB
+    double m_startGpuSharedMemory;    // in MB
+    double m_deltaGpuDedicatedMemory; // in MB
+    double m_deltaGpuSharedMemory;    // in MB
 };
 
 #endif
@@ -398,21 +425,18 @@ typedef enum CounterType
     TYPE_COUNT
 } CounterType;
 
-const static std::vector<std::wstring> CounterTypeName =
-{
-    L"TIMER",
-    L"CPU USAGE",
-    L"PAGE FAULT COUNT",
-    L"PAGE FILE USAGE",
-    L"PEAK PAGE FILE USAGE",
-    L"WORKING SET USAGE",
-    L"PEAK WORK SET USAGE",
-    L"GPU USAGE",
-    L"GPU_DEDICATED_MEM_USAGE",
-    L"GPU_SHARED_MEM_USAGE",
-    L"STARTING_WORKING_SET",
-    L"STARTING_SHARED_MEM"
-};
+const static std::vector<std::wstring> CounterTypeName = {L"TIMER",
+                                                          L"CPU USAGE",
+                                                          L"PAGE FAULT COUNT",
+                                                          L"PAGE FILE USAGE",
+                                                          L"PEAK PAGE FILE USAGE",
+                                                          L"WORKING SET USAGE",
+                                                          L"PEAK WORK SET USAGE",
+                                                          L"GPU USAGE",
+                                                          L"GPU_DEDICATED_MEM_USAGE",
+                                                          L"GPU_SHARED_MEM_USAGE",
+                                                          L"STARTING_WORKING_SET",
+                                                          L"STARTING_SHARED_MEM"};
 
 class PerfCounterStatistics
 {
@@ -424,15 +448,9 @@ public:
         m_bDisabled = true;
     }
 
-    void Enable()
-    {
-        m_bDisabled = false;
-    }
+    void Enable() { m_bDisabled = false; }
 
-    void Disable()
-    {
-        m_bDisabled = true;
-    }
+    void Disable() { m_bDisabled = true; }
 
     void Reset()
     {
@@ -555,7 +573,7 @@ private:
             max = 0;
             min = DBL_MAX;
             total = 0;
-            memset(measured, 0, sizeof(double)*TIMER_SLOT_SIZE);
+            memset(measured, 0, sizeof(double) * TIMER_SLOT_SIZE);
         }
 
         double max;
@@ -583,11 +601,9 @@ private:
     double GpuDedicatedDiff;
 };
 
-
 // A class to wrap up multiple PerfCounterStatistics objects.
 // To create a profiler, define intervals in an enum and use it to create the profiler object.
-template<typename T>
-class Profiler
+template <typename T> class Profiler
 {
 public:
     void Reset(int begin, int end)
@@ -598,25 +614,13 @@ public:
         }
     }
 
-    void Reset()
-    {
-        Reset(0, T::COUNT);
-    }
+    void Reset() { Reset(0, T::COUNT); }
 
-    PerfCounterStatistics& GetCounter(int t) const
-    {
-        return m_perfCounterStat[t];
-    }
+    PerfCounterStatistics &GetCounter(int t) const { return m_perfCounterStat[t]; }
 
-    PerfCounterStatistics& operator [] (int t)
-    {
-        return m_perfCounterStat[t];
-    }
+    PerfCounterStatistics &operator[](int t) { return m_perfCounterStat[t]; }
 
-    const PerfCounterStatistics& operator [] (int t) const
-    {
-        return m_perfCounterStat[t];
-    }
+    const PerfCounterStatistics &operator[](int t) const { return m_perfCounterStat[t]; }
 
     void Enable()
     {
@@ -644,6 +648,12 @@ private:
 #define WINML_PROFILING_START(profiler, interval) profiler[interval].Start()
 #define WINML_PROFILING_STOP(profiler, interval) profiler[interval].Stop()
 #else
-#define WINML_PROFILING_START(profiler, interval) do {} while(0)
-#define WINML_PROFILING_STOP(profiler, interval) do {} while(0)
+#define WINML_PROFILING_START(profiler, interval)                                                                      \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (0)
+#define WINML_PROFILING_STOP(profiler, interval)                                                                       \
+    do                                                                                                                 \
+    {                                                                                                                  \
+    } while (0)
 #endif

--- a/Tools/WinMLRunner/src/dllload.cpp
+++ b/Tools/WinMLRunner/src/dllload.cpp
@@ -13,8 +13,6 @@ extern "C"
 #pragma comment(linker, "/alternatename:OS_RoGetActivationFactory=RoGetActivationFactory")
 #endif
 
-
-
 bool starts_with(std::wstring_view value, std::wstring_view match) noexcept
 {
     return 0 == value.compare(0, match.size(), match);
@@ -23,7 +21,8 @@ bool starts_with(std::wstring_view value, std::wstring_view match) noexcept
 int32_t __stdcall WINRT_RoGetActivationFactory(void* classId, winrt::guid const& iid, void** factory) noexcept
 {
     *factory = nullptr;
-    std::wstring_view name{ WindowsGetStringRawBuffer(static_cast<HSTRING>(classId), nullptr), WindowsGetStringLen(static_cast<HSTRING>(classId)) };
+    std::wstring_view name{ WindowsGetStringRawBuffer(static_cast<HSTRING>(classId), nullptr),
+                            WindowsGetStringLen(static_cast<HSTRING>(classId)) };
     HMODULE library{ nullptr };
 
     std::wstring winmlDllPath = FileHelper::GetModulePath() + L"Windows.AI.MachineLearning.dll";


### PR DESCRIPTION
Refactor WinMLRunner using clang format. You can use any of the clang format extension and clang-format file to reformat the code 