### PR TITLE
User/orilevari/outputdebugtosubdirectories

### DIFF
--- a/Samples/CustomOperatorCPU/desktop/cpp/custom-operator-cpu-sample.sln
+++ b/Samples/CustomOperatorCPU/desktop/cpp/custom-operator-cpu-sample.sln
@@ -19,8 +19,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|ARM.ActiveCfg = Release|ARM
-		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x64.ActiveCfg = Debug|Win32
-		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x64.Build.0 = Debug|Win32
+		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x64.ActiveCfg = Debug|x64
+		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x64.Build.0 = Debug|x64
 		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x86.ActiveCfg = Debug|Win32
 		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Debug|x86.Build.0 = Debug|Win32
 		{2BF804D4-DAA2-42BE-9F21-0E94F021EF53}.Release|Any CPU.ActiveCfg = Release|Win32

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -298,7 +298,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
 {
     MLOperatorSetId operatorSetId;
     operatorSetId.domain = "";
-    operatorSetId.version = 8;
+    operatorSetId.version = 7;
 
     MLOperatorSchemaDescription debugSchema;
     debugSchema.name = "Debug";
@@ -384,7 +384,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
     std::vector<const MLOperatorSchemaDescription*> schemas{ &debugSchema };
     registry->RegisterOperatorSetSchema(
         &operatorSetId,
-        8 /* baseline version */,
+        7 /* baseline version */,
         schemas.data(),
         static_cast<uint32_t>(schemas.size()),
         nullptr,

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -79,7 +79,6 @@ void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring
     wchar_t buf[MAX_PATH];
     _wgetcwd(buf, 256);
     StorageFolder parentFolder = StorageFolder::GetFolderFromPathAsync(buf).get();
-	CreateOutputSubDirectories(m_filePath);
     int pixelsPerImage = inputDims.at(HEIGHT) * inputDims.at(WIDTH);
 
     // for each output channel at this point in the network
@@ -118,7 +117,12 @@ void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring
 
 template <typename T>
 void WriteToText(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring m_filePath, MLOperatorTensorDataType dataType) {
-	CreateOutputSubDirectories(m_filePath);
+    // Get current directory
+    wchar_t buf[MAX_PATH];
+    _wgetcwd(buf, 256);
+    StorageFolder parentFolder = StorageFolder::GetFolderFromPathAsync(buf).get();
+    parentFolder.CreateFileAsync(m_filePath, CreationCollisionOption::ReplaceExisting).get();
+
     ofstream outputFile;
     outputFile.open(winrt::to_string(m_filePath));
     outputFile << "dimensions: ";

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -363,7 +363,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
     std::vector<const MLOperatorSchemaDescription*> schemas{ &debugSchema };
     registry->RegisterOperatorSetSchema(
         &operatorSetId,
-		TARGET_OPSET /* baseline version */,
+        TARGET_OPSET /* baseline version */,
         schemas.data(),
         static_cast<uint32_t>(schemas.size()),
         nullptr,

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -38,28 +38,6 @@ HRESULT DebugShapeInferrer::InferOutputShapes (IMLOperatorShapeInferenceContext*
     }
 }
 
-// returns deepest subdirectory created
-void CreateOutputSubDirectories(hstring hpath) {
-	static const std::wstring separators(L"\\/");
-	std::wstring path{ hpath };
-
-	wchar_t buf[MAX_PATH];
-	_wgetcwd(buf, 256);
-	StorageFolder currFolder = StorageFolder::GetFolderFromPathAsync(buf).get();
-
-	std::size_t separatorIdx = path.find_first_of(separators);
-	while (separatorIdx < path.size() - 1) {
-		std::wstring nextDir = path.substr(0, separatorIdx);
-		path = path.substr(separatorIdx + 1);
-		// creates folder if it doesn't already exists and returns said folder
-		if (nextDir.size() > 0) {
-			currFolder = currFolder.CreateFolderAsync(nextDir, CreationCollisionOption::OpenIfExists).get();
-		}
-		// find the next subdirectory to make
-		separatorIdx = path.find_first_of(separators);
-	}
-}
-
 template <typename T>
 void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring m_filePath)
 {    

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -17,6 +17,7 @@ static const int CHANNELS = 1;
 static const int HEIGHT = 2;
 static const int WIDTH = 3;
 static const int NUM_DIMENSIONS = 4;
+static const int TARGET_OPSET = 7;
 
 HRESULT DebugShapeInferrer::InferOutputShapes (IMLOperatorShapeInferenceContext* context) noexcept
 {
@@ -298,7 +299,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
 {
     MLOperatorSetId operatorSetId;
     operatorSetId.domain = "";
-    operatorSetId.version = 7;
+    operatorSetId.version = TARGET_OPSET;
 
     MLOperatorSchemaDescription debugSchema;
     debugSchema.name = "Debug";
@@ -384,7 +385,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
     std::vector<const MLOperatorSchemaDescription*> schemas{ &debugSchema };
     registry->RegisterOperatorSetSchema(
         &operatorSetId,
-        7 /* baseline version */,
+		TARGET_OPSET /* baseline version */,
         schemas.data(),
         static_cast<uint32_t>(schemas.size()),
         nullptr,

--- a/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
+++ b/Samples/CustomOperatorCPU/desktop/cpp/operators/debug_cpu.cpp
@@ -37,6 +37,28 @@ HRESULT DebugShapeInferrer::InferOutputShapes (IMLOperatorShapeInferenceContext*
     }
 }
 
+// returns deepest subdirectory created
+void CreateOutputSubDirectories(hstring hpath) {
+	static const std::wstring separators(L"\\/");
+	std::wstring path{ hpath };
+
+	wchar_t buf[MAX_PATH];
+	_wgetcwd(buf, 256);
+	StorageFolder currFolder = StorageFolder::GetFolderFromPathAsync(buf).get();
+
+	std::size_t separatorIdx = path.find_first_of(separators);
+	while (separatorIdx < path.size() - 1) {
+		std::wstring nextDir = path.substr(0, separatorIdx);
+		path = path.substr(separatorIdx + 1);
+		// creates folder if it doesn't already exists and returns said folder
+		if (nextDir.size() > 0) {
+			currFolder = currFolder.CreateFolderAsync(nextDir, CreationCollisionOption::OpenIfExists).get();
+		}
+		// find the next subdirectory to make
+		separatorIdx = path.find_first_of(separators);
+	}
+}
+
 template <typename T>
 void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring m_filePath)
 {    
@@ -57,6 +79,7 @@ void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring
     wchar_t buf[MAX_PATH];
     _wgetcwd(buf, 256);
     StorageFolder parentFolder = StorageFolder::GetFolderFromPathAsync(buf).get();
+	CreateOutputSubDirectories(m_filePath);
     int pixelsPerImage = inputDims.at(HEIGHT) * inputDims.at(WIDTH);
 
     // for each output channel at this point in the network
@@ -95,6 +118,7 @@ void WriteToPng(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring
 
 template <typename T>
 void WriteToText(vector<uint32_t> inputDims, T* inputData, uint32_t size, hstring m_filePath, MLOperatorTensorDataType dataType) {
+	CreateOutputSubDirectories(m_filePath);
     ofstream outputFile;
     outputFile.open(winrt::to_string(m_filePath));
     outputFile << "dimensions: ";
@@ -270,7 +294,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
 {
     MLOperatorSetId operatorSetId;
     operatorSetId.domain = "";
-    operatorSetId.version = 7;
+    operatorSetId.version = 8;
 
     MLOperatorSchemaDescription debugSchema;
     debugSchema.name = "Debug";
@@ -356,7 +380,7 @@ void DebugOperatorFactory::RegisterDebugSchema(winrt::com_ptr<IMLOperatorRegistr
     std::vector<const MLOperatorSchemaDescription*> schemas{ &debugSchema };
     registry->RegisterOperatorSetSchema(
         &operatorSetId,
-        7 /* baseline version */,
+        8 /* baseline version */,
         schemas.data(),
         static_cast<uint32_t>(schemas.size()),
         nullptr,


### PR DESCRIPTION
Fix for Bug 9266: https://mscodehub.visualstudio.com/WindowsAI/_workitems/edit/9266/

When using the debug custom operator code, writing to an output path with subdirectories that do not exist would fail. Now I use StorageFolder.createFileAsync since it handles nested subdirectory creation.

I also corrected a config issue where if you selected x64, Debug, it would build Win32.

Finally, I refactored the custom operator version into a static const for clarity.