### PR TITLE
azure pipelines fixes

### DIFF
--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -6,10 +6,7 @@
 variables:
 
   SamplesBin: SamplesBin
-  system.collectionId: ee8504d9-65a6-4f6c-85ed-0ad4265128ee
   system.debug: false
-  system.definitionId: 612
-  system.teamProject: WindowsAI
   WINDOWS_WINMD: C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.17763.0\Windows.winmd
 
 strategy:
@@ -28,14 +25,23 @@ strategy:
       BuildPlatform: x86
       BuildConfiguration: Debug
 
-# specific branch build
+# CI trigger
 trigger:
   branches:
     include:
     - master
   paths:
+    exclude:
+    - Tools
+
+# PR validation trigger
+pr:
+  branches:
     include:
-    - Samples
+    - master
+  paths:
+    exclude:
+    - Tools
 
 steps: 
   - task: PowerShell@2


### PR DESCRIPTION
1) remove build variables from yaml which now are causing early error in the build pipeline. Seems as if it is due to a change in azure pipelines behavior: https://mscodehub.visualstudio.com/WindowsAI/_build/results?buildId=85261&view=results
2) Also add pull request validation and change filtering of paths to just exclude the Tools directory since it is only the Tools directory which is properly testing by other pipelines