### PR TITLE
Add programmatic capture for PIX tool

### DIFF
--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -41,6 +41,12 @@ enum WINML_MODEL_TEST_PERF
 
 using namespace winrt;
 
+#define THROW_IF_FAILED(hr)                                                                                            \
+    {                                                                                                                  \
+        if (FAILED(hr))                                                                                                \
+            throw hresult_error(hr);                                                                                   \
+    }
+
 inline std::wstring MakeErrorMsg(HRESULT hr)
 {
     std::wostringstream ss;

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -11,6 +11,7 @@
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 #include <direct.h>
 #include <queue>
+#include <DXProgrammableCapture.h>
 
 using namespace winrt::Windows::AI::MachineLearning;
 using namespace winrt::Windows::Storage::Streams;
@@ -962,7 +963,7 @@ public:
     std::vector<double> m_clockEvalTimes;
 
     std::wstring getCsvFileNamePerIterationResult() { return m_csvFileNamePerIterationResult; }
-
+    com_ptr<IDXGraphicsAnalysis>& GetGraphicsAnalysis() { return m_graphicsAnalysis; }
 private:
     std::wstring m_csvFileName;
     std::wstring m_csvFileNamePerIterationSummary;
@@ -981,4 +982,5 @@ private:
     std::vector<double> m_GPUDedicatedDiff;
     std::vector<std::string> m_outputResult;
     std::vector<int> m_outputTensorHash;
+    com_ptr<IDXGraphicsAnalysis> m_graphicsAnalysis = nullptr;
 };

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -11,7 +11,11 @@
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 #include <direct.h>
 #include <queue>
+
+#if defined(_AMD64_)
+// PIX markers only work on amd64
 #include <DXProgrammableCapture.h>
+#endif
 
 using namespace winrt::Windows::AI::MachineLearning;
 using namespace winrt::Windows::Storage::Streams;
@@ -963,7 +967,10 @@ public:
     std::vector<double> m_clockEvalTimes;
 
     std::wstring getCsvFileNamePerIterationResult() { return m_csvFileNamePerIterationResult; }
+#if defined(_AMD64_)
+    // PIX markers only work on amd64
     com_ptr<IDXGraphicsAnalysis>& GetGraphicsAnalysis() { return m_graphicsAnalysis; }
+#endif
 private:
     std::wstring m_csvFileName;
     std::wstring m_csvFileNamePerIterationSummary;
@@ -982,5 +989,9 @@ private:
     std::vector<double> m_GPUDedicatedDiff;
     std::vector<std::string> m_outputResult;
     std::vector<int> m_outputTensorHash;
+
+#if defined(_AMD64_)
+    // PIX markers only work on amd64
     com_ptr<IDXGraphicsAnalysis> m_graphicsAnalysis = nullptr;
+#endif
 };

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -191,12 +191,15 @@ HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, O
 
     LearningModelSession session = nullptr;
     IDirect3DDevice winrtDevice = nullptr;
+#if defined(_AMD64_)
+    // PIX markers only work on AMD64
     if (output.GetGraphicsAnalysis().get())
     {
         // If PIX tool is attached to WinMLRunner then begin capture. First capture will include
         // session creation, first iteration bind and first iteration evaluate.
         output.GetGraphicsAnalysis()->BeginCapture();
     }
+#endif
     try
     {
         if (deviceCreationLocation == DeviceCreationLocation::ClientCode && deviceType != DeviceType::CPU)
@@ -306,12 +309,16 @@ HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, O
             std::wcout << hr.message().c_str() << std::endl;
             return hr.code();
         }
+
+#if defined(_AMD64_)
+        // PIX markers only work on AMD64
         // If PIX tool was attached then capture already began for the first iteration before session creation.
         // This is to begin PIX capture for each iteration after the first iteration.
         if (i > 0 && output.GetGraphicsAnalysis())
         {
             output.GetGraphicsAnalysis()->BeginCapture();
         }
+#endif
         HRESULT bindInputResult =
             BindInputFeatures(model, context, inputFeatures, args, output, captureIterationPerf, i, profiler);
 
@@ -348,11 +355,14 @@ HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, O
                 completionString = "[SUCCESS]\n";
             }
         }
+#if defined(_AMD64_)
+        // PIX markers only work on AMD64
         if (output.GetGraphicsAnalysis())
         {
             // If PIX tool is attached, then end the capture
             output.GetGraphicsAnalysis()->EndCapture();
         }
+#endif
     }
     printf("%s", completionString.c_str());
 
@@ -562,12 +572,15 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler)
     winrt::init_apartment();
     OutputHelper output(args.NumIterations());
 
+#if defined(_AMD64_)
+    // PIX markers only work on AMD64
     // Check if PIX tool is attached to WinMLRunner
     // Try to acquire IDXGraphicsAnalysis - this only succeeds if PIX is attached
     if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(output.GetGraphicsAnalysis().put()))))
     {
         std::cout << "Detected PIX tool is attached to WinMLRunner" << std::endl;
     }
+#endif
 
     // Profiler is a wrapper class that captures and stores timing and memory usage data on the
     // CPU and GPU.

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -193,8 +193,8 @@ HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, O
     IDirect3DDevice winrtDevice = nullptr;
     if (output.GetGraphicsAnalysis().get())
     {
-        // If PIX tool is attached to WinMLRunner then begin capture for Session Creation, and 
-        // the first iteration of bind and evaluate
+        // If PIX tool is attached to WinMLRunner then begin capture. First capture will include
+        // session creation, first iteration bind and first iteration evaluate.
         output.GetGraphicsAnalysis()->BeginCapture();
     }
     try
@@ -307,7 +307,7 @@ HRESULT EvaluateModel(const LearningModel& model, const CommandLineArgs& args, O
             return hr.code();
         }
         // If PIX tool was attached then capture already began for the first iteration before session creation.
-        // This is to begin capture for iterations after the first one. 
+        // This is to begin PIX capture for each iteration after the first iteration.
         if (i > 0 && output.GetGraphicsAnalysis())
         {
             output.GetGraphicsAnalysis()->BeginCapture();


### PR DESCRIPTION
Before this change, if a user wanted to capture GPU workload with WinMLRunner using PIX, the user would have to click the "camera" button in the UI of PIX tool which isn't always reliable. 

This change detects if PIX tool is attached to WinMLRunner and automatically capture. This is more reliable since it gives WinMLRunner control of when to start / stop capture and what information each PIX frame has.

- 1st Frame: Will contain PIX captures for Session Creation and 1st iteration Bind, 1st iteration Evaluate
- Nth Frame: Will contain PIX captures for Nth iteration Bind and Nth iteration Evaluate