### PR TITLE
Modify debug_all_outputs.py

### DIFF
--- a/Samples/CustomOperatorCPU/customize_model/scripts/debug_all_outputs.py
+++ b/Samples/CustomOperatorCPU/customize_model/scripts/debug_all_outputs.py
@@ -18,7 +18,8 @@ def create_modified_model(args):
         for output in node.output:
             intermediate_outputs.add(output)
 
-    # remove final graph outputs
+    # remove final graph outputs (see the definition of graph outputs in the onnx standard: https://github.com/onnx/onnx/blob/master/docs/IR.md#user-content-graphs)
+    # it would be invalid to add debug operators after the final graph outputs since execution must be finished once all outputs are written to
     for output in model.graph.output:
         intermediate_outputs.remove(output.name)
 

--- a/Samples/CustomOperatorCPU/customize_model/scripts/debug_all_outputs.py
+++ b/Samples/CustomOperatorCPU/customize_model/scripts/debug_all_outputs.py
@@ -18,6 +18,10 @@ def create_modified_model(args):
         for output in node.output:
             intermediate_outputs.add(output)
 
+    # remove final graph outputs
+    for output in model.graph.output:
+        intermediate_outputs.remove(output.name)
+
     # create a debug operator that consumes each intermediate output
     # debug operator file path attribute is constructed by the name of the intermediate output
     for output in intermediate_outputs:


### PR DESCRIPTION
This pull request changes the debug_all_outputs.py helper script to not insert a debug custom operator after any final graph outputs, because this was violating the onnx standard and causing a bug due to undefined behavior