### PR TITLE
Add back DxCore support to WinMLRunner

### DIFF
--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -35,7 +35,6 @@ Required command-Line arguments:
 -GPU : run model on default GPU
 -GPUHighPerformance : run model on GPU with highest performance
 -GPUMinPower : run model on GPU with the least power
--GPUAdapterIndex <index number> : run model on GPU specified by its DXCore index. NOTE: Please only use this flag on DXCore supported machines.
 -GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines.
 -CreateDeviceOnClient : create the D3D device on the client and pass it to WinML to create session
 -CreateDeviceInWinML : create the device inside WinML

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -35,6 +35,8 @@ Required command-Line arguments:
 -GPU : run model on default GPU
 -GPUHighPerformance : run model on GPU with highest performance
 -GPUMinPower : run model on GPU with the least power
+-GPUAdapterIndex <index number> : run model on GPU specified by its DXCore index. NOTE: Please only use this flag on DXCore supported machines.
+-GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines.
 -CreateDeviceOnClient : create the D3D device on the client and pass it to WinML to create session
 -CreateDeviceInWinML : create the device inside WinML
 -CPUBoundInput : bind the input to the CPU

--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -160,6 +160,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)src\GenerateVersionStrings.cmd $(ProjectDir) $(IntDir)</Command>
@@ -185,6 +186,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -211,6 +213,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -241,6 +244,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -272,6 +276,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -304,6 +309,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)src\GenerateVersionStrings.cmd $(ProjectDir) $(IntDir)</Command>

--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -186,7 +186,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
-      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -213,7 +213,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
-      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -244,7 +244,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
-      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -276,7 +276,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
-      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(IntDir)</AdditionalIncludeDirectories>
@@ -309,7 +309,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
-      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0"</DelayLoadDLLs>
+      <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
       <Command>$(ProjectDir)src\GenerateVersionStrings.cmd $(ProjectDir) $(IntDir)</Command>

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -20,8 +20,6 @@ void CommandLineArgs::PrintUsage()
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
 #ifdef DXCORE_SUPPORTED_BUILD
-    std::cout << "  -GPUAdapterIndex <index number> : run model on GPU specified by its DXCore index. NOTE: Please only use this flag on DXCore supported machines."
-              << std::endl;
     std::cout << "  -GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines." 
               << std::endl;
 #endif
@@ -103,17 +101,9 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
             {
                 throw hresult_invalid_argument(
                     L"ERROR: DXCORE isn't supported on this machine. "
-                    L"GpuAdapterName and GpuAdapterIndex flag "
-                    L"should only be used with DXCore supported machines.");
+                    L"GpuAdapterName flag should only be used with DXCore supported machines.");
                 }
-            if (_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0)
-            {
-                m_adapterIndex = static_cast<UINT>(_wtoi(args[++i].c_str()));
-            }
-            else
-            {
-                m_adapterName = args[++i];
-            }
+            m_adapterName = args[++i];
             m_useGPU = true;
         }
 #endif
@@ -367,10 +357,4 @@ void CommandLineArgs::CheckForInvalidArguments()
     {
         throw hresult_invalid_argument(L"Cannot save tensor output if no input data is provided!");
     }
-#ifdef DXCORE_SUPPORTED_BUILD
-    if (m_adapterIndex != -1 && !m_adapterName.empty())
-    {
-        throw hresult_invalid_argument(L"Cannot use both -GpuAdapterIndex and -GpuAdapterName");
-    }
-#endif
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -19,7 +19,7 @@ void CommandLineArgs::PrintUsage()
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
-#ifdef MCDM_BUILD
+#ifdef DXCORE_SUPPORTED_BUILD
     std::cout << "  -GPUAdapterIndex <index number> : run model on GPU specified by its DXCore index. NOTE: Please only use this flag on DXCore supported machines."
               << std::endl;
     std::cout << "  -GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines." 
@@ -93,7 +93,7 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
         {
             m_useGPUMinPower = true;
         }
-#ifdef MCDM_BUILD
+#ifdef DXCORE_SUPPORTED_BUILD
         else if ((_wcsicmp(args[i].c_str(), L"-GPUAdapterName") == 0) || (_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0))
         {
             CheckNextArgument(args, i);
@@ -101,11 +101,11 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
             library = LoadLibrary(L"dxcore.dll");
             if (!library)
             {
-              throw hresult_invalid_argument(
-                  L"ERROR: DXCORE isn't supported on this machine. "
-                  L"GpuAdapterName and GpuAdapterIndex flag "
-                  L"should only be used with DXCore supported machines.");
-            }
+                throw hresult_invalid_argument(
+                    L"ERROR: DXCORE isn't supported on this machine. "
+                    L"GpuAdapterName and GpuAdapterIndex flag "
+                    L"should only be used with DXCore supported machines.");
+                }
             if (_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0)
             {
                 m_adapterIndex = static_cast<UINT>(_wtoi(args[++i].c_str()));
@@ -367,7 +367,7 @@ void CommandLineArgs::CheckForInvalidArguments()
     {
         throw hresult_invalid_argument(L"Cannot save tensor output if no input data is provided!");
     }
-#ifdef MCDM_BUILD
+#ifdef DXCORE_SUPPORTED_BUILD
     if (m_adapterIndex != -1 && !m_adapterName.empty())
     {
         throw hresult_invalid_argument(L"Cannot use both -GpuAdapterIndex and -GpuAdapterName");

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -32,7 +32,6 @@ public:
     const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
 #ifdef DXCORE_SUPPORTED_BUILD
     const std::wstring& GetGPUAdapterName() const { return m_adapterName; }
-    UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
 #endif
 
     bool UseRGB() const
@@ -144,7 +143,6 @@ private:
     std::wstring m_csvData;
     std::wstring m_inputData;
 #ifdef DXCORE_SUPPORTED_BUILD
-    UINT m_adapterIndex = -1;
     std::wstring m_adapterName;
 #endif
     std::wstring m_perfOutputPath;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -30,6 +30,10 @@ public:
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
     const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
+#ifdef MCDM_BUILD
+    const std::wstring& GetGPUAdapterName() const { return m_adapterName; }
+    UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
+#endif
 
     bool UseRGB() const
     {
@@ -139,6 +143,10 @@ private:
     std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
+#ifdef MCDM_BUILD
+    UINT m_adapterIndex = -1;
+    std::wstring m_adapterName;
+#endif
     std::wstring m_perfOutputPath;
     std::wstring m_tensorOutputPath;
     uint32_t m_numIterations = 1;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -30,7 +30,7 @@ public:
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
     const std::wstring& ModelPath() const { return m_modelPath; }
     const std::wstring& TensorOutputPath() const { return m_tensorOutputPath; }
-#ifdef MCDM_BUILD
+#ifdef DXCORE_SUPPORTED_BUILD
     const std::wstring& GetGPUAdapterName() const { return m_adapterName; }
     UINT GetGPUAdapterIndex() const { return m_adapterIndex; }
 #endif
@@ -143,7 +143,7 @@ private:
     std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
-#ifdef MCDM_BUILD
+#ifdef DXCORE_SUPPORTED_BUILD
     UINT m_adapterIndex = -1;
     std::wstring m_adapterName;
 #endif

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -28,7 +28,7 @@
 #if __has_include("dxcore.h")
 #include <initguid.h>
 #include <dxcore.h>
-#define MCDM_BUILD
+#define DXCORE_SUPPORTED_BUILD
 #endif
 
 enum WINML_MODEL_TEST_PERF

--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -25,6 +25,12 @@
 #include "TimerHelper.h"
 #include "DirectXPackedVector.h"
 
+#if __has_include("dxcore.h")
+#include <initguid.h>
+#include <dxcore.h>
+#define MCDM_BUILD
+#endif
+
 enum WINML_MODEL_TEST_PERF
 {
     ENTIRE_TEST = 0,

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -183,135 +183,125 @@ HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevic
 #ifdef DXCORE_SUPPORTED_BUILD
         else if ((TypeHelper::GetWinmlDeviceKind(deviceType) != LearningModelDeviceKind::Cpu) &&
                  (!adapterName.empty() || adapterIndex != -1))
-        {
-            com_ptr<IDXCoreAdapterFactory> spFactory;
-            THROW_IF_FAILED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(spFactory.put())));
+             {
+             com_ptr<IDXCoreAdapterFactory> spFactory;
+             THROW_IF_FAILED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(spFactory.put())));
 
-            com_ptr<IDXCoreAdapterList> spAdapterList;
-            const GUID dxGUIDs[] = { DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
+             com_ptr<IDXCoreAdapterList> spAdapterList;
+             const GUID dxGUIDs[] = { DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
 
-            THROW_IF_FAILED(spFactory->GetAdapterList(dxGUIDs, ARRAYSIZE(dxGUIDs), spAdapterList.put()));
+             THROW_IF_FAILED(spFactory->GetAdapterList(dxGUIDs, ARRAYSIZE(dxGUIDs), spAdapterList.put()));
 
-            std::map<int, com_ptr<IDXCoreAdapter>> validAdapters;
-            printf("Printing available adapters..\n");
-            for (UINT i = 0; i < spAdapterList->GetAdapterCount(); i++)
-            {
-                com_ptr<IDXCoreAdapter> spAdapter;
-                THROW_IF_FAILED(spAdapterList->GetItem(i, spAdapter.put()));
-                // If the adapter is a software adapter then don't consider it
-                bool isHardware;
-                size_t driverDescriptionSize;
-                THROW_IF_FAILED(
-                    spAdapter->QueryPropertySize(DXCoreProperty::DriverDescription, &driverDescriptionSize));
-                CHAR* driverDescription = new CHAR[driverDescriptionSize];
-                THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::IsHardware, sizeof(isHardware), &isHardware));
-                if (isHardware)
-                {
-                    THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::DriverDescription, driverDescriptionSize,
-                                                             driverDescription));
-                    printf("Index: %d, Description: %s\n", i, driverDescription);
-                    validAdapters[i] = spAdapter;
-                }
-                free(driverDescription);
-            }
+             std::map<int, com_ptr<IDXCoreAdapter>> validAdapters;
+             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+             std::string adapterNameStr = converter.to_bytes(adapterName);
+             com_ptr<IDXCoreAdapter> spAdapter = nullptr;
+             printf("Printing available adapters..\n");
+             for (UINT i = 0; i < spAdapterList->GetAdapterCount(); i++)
+             {
+                 THROW_IF_FAILED(spAdapterList->GetItem(i, spAdapter.put()));
 
-            com_ptr<IDXCoreAdapter> spAdapter = nullptr;
-            if (adapterIndex != -1) // Use index to retrieve adapter
-            {
-                if (validAdapters.find(adapterIndex) != validAdapters.end())
-                {
-                    spAdapter = validAdapters[adapterIndex];
-                }
-                else
-                {
-                    throw hresult_invalid_argument(L"ERROR: No matching adapter with index provided: " +
-                                                   std::to_wstring(adapterIndex));
-                }
-            }
-            else // Use name to retrieve adapter
-            {
-                std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-                std::string adapterNameStr = converter.to_bytes(adapterName);
-                for (auto it = validAdapters.begin(); it != validAdapters.end(); it++)
-                {
-                    size_t driverDescriptionSize;
-                    THROW_IF_FAILED(
-                        spAdapter->QueryPropertySize(DXCoreProperty::DriverDescription, &driverDescriptionSize));
-                    CHAR* driverDescription = new CHAR[driverDescriptionSize];
-                    THROW_IF_FAILED(it->second->QueryProperty(DXCoreProperty::DriverDescription, driverDescriptionSize,
+                 // If the adapter is a software adapter then don't consider it for index selection
+                 bool isHardware;
+                 size_t driverDescriptionSize;
+                 THROW_IF_FAILED(
+                     spAdapter->QueryPropertySize(DXCoreProperty::DriverDescription, &driverDescriptionSize));
+                 CHAR* driverDescription = new CHAR[driverDescriptionSize];
+                 THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::IsHardware, sizeof(isHardware), &isHardware));
+                 if (isHardware)
+                 {
+                     THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::DriverDescription, driverDescriptionSize,
                                                               driverDescription));
-                    std::string driverDescriptionStr = std::string(driverDescription);
-                    std::transform(driverDescriptionStr.begin(), driverDescriptionStr.end(),
-                                   driverDescriptionStr.begin(), ::tolower);
-                    std::transform(adapterNameStr.begin(), adapterNameStr.end(), adapterNameStr.begin(), ::tolower);
-                    if (strstr(driverDescriptionStr.c_str(), adapterNameStr.c_str()))
-                    {
-                        spAdapter = it->second;
-                        break;
-                    }
-                    free(driverDescription);
-                }
-                if (spAdapter == nullptr)
-                {
-                    throw hresult_invalid_argument(L"ERROR: No matching adapter with given adapter name: " +
-                                                   adapterName);
-                }
-            }
-            size_t driverDescriptionSize;
-            THROW_IF_FAILED(spAdapter->QueryPropertySize(DXCoreProperty::DriverDescription, &driverDescriptionSize));
-            CHAR* driverDescription = new CHAR[driverDescriptionSize];
-            spAdapter->QueryProperty(DXCoreProperty::DriverDescription, sizeof(driverDescription), driverDescription);
-            printf("Using adapter : %s\n", driverDescription);
-            free(driverDescription);
-            IUnknown* pAdapter = spAdapter.get();
-            com_ptr<IDXGIAdapter> spDxgiAdapter;
-            D3D_FEATURE_LEVEL d3dFeatureLevel = D3D_FEATURE_LEVEL_1_0_CORE;
-            D3D12_COMMAND_LIST_TYPE commandQueueType = D3D12_COMMAND_LIST_TYPE_COMPUTE;
+                     printf("Index: %d, Description: %s\n", i, driverDescription);
+                     validAdapters[i] = spAdapter;
+                 }
 
-            // Check if adapter selected has DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX attribute selected. If so,
-            // then GPU was selected that has D3D12 and D3D11 capabilities. It would be the most stable to
-            // use DXGI to enumerate GPU and use D3D_FEATURE_LEVEL_11_0 so that image tensorization for
-            // video frames would be able to happen on the GPU.
-            if (spAdapter->IsDXAttributeSupported(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX))
-            {
-                d3dFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0;
-                com_ptr<IDXGIFactory4> dxgiFactory4;
-                THROW_IF_FAILED(CreateDXGIFactory2(0, __uuidof(IDXGIFactory4), dxgiFactory4.put_void()));
+                 std::string driverDescriptionStr = std::string(driverDescription);
+                 std::transform(driverDescriptionStr.begin(), driverDescriptionStr.end(), driverDescriptionStr.begin(),
+                                ::tolower);
+                 std::transform(adapterNameStr.begin(), adapterNameStr.end(), adapterNameStr.begin(), ::tolower);
+                 if (strstr(driverDescriptionStr.c_str(), adapterNameStr.c_str()))
+                 {
+                     break;
+                 }
+                 free(driverDescription);
+                 spAdapter = nullptr;
+             }
+             if (adapterIndex != -1) // Use index to retrieve adapter
+             {
+                 if (validAdapters.find(adapterIndex) != validAdapters.end())
+                 {
+                        spAdapter = validAdapters[adapterIndex];
+                 }
+                 else
+                 {
+                     throw hresult_invalid_argument(L"ERROR: No matching adapter with index provided: " +
+                                                    std::to_wstring(adapterIndex));
+                 }
+             }
+             else // Use name to retrieve adapter
+             {
+                 if (spAdapter == nullptr)
+                 {
+                     throw hresult_invalid_argument(L"ERROR: No matching adapter with given adapter name: " +
+                                                    adapterName);
+                 }
+             }
+             size_t driverDescriptionSize;
+             THROW_IF_FAILED(spAdapter->QueryPropertySize(DXCoreProperty::DriverDescription, &driverDescriptionSize));
+             CHAR* driverDescription = new CHAR[driverDescriptionSize];
+             spAdapter->QueryProperty(DXCoreProperty::DriverDescription, sizeof(driverDescription), driverDescription);
+             printf("Using adapter : %s\n", driverDescription);
+             free(driverDescription);
+             IUnknown* pAdapter = spAdapter.get();
+             com_ptr<IDXGIAdapter> spDxgiAdapter;
+             D3D_FEATURE_LEVEL d3dFeatureLevel = D3D_FEATURE_LEVEL_1_0_CORE;
+             D3D12_COMMAND_LIST_TYPE commandQueueType = D3D12_COMMAND_LIST_TYPE_COMPUTE;
 
-                // If DXGI factory creation was successful then get the IDXGIAdapter from the LUID acquired from the
-                // selectedAdapter
-                LUID adapterLuid;
-                THROW_IF_FAILED(spAdapter->GetLUID(&adapterLuid));
-                THROW_IF_FAILED(
-                    dxgiFactory4->EnumAdapterByLuid(adapterLuid, __uuidof(IDXGIAdapter), spDxgiAdapter.put_void()));
-                pAdapter = spDxgiAdapter.get();
-            }
-            else
-            {
-                // Need to enable experimental features to create D3D12 Device with adapter that has compute only
-                // capabilities.
-                THROW_IF_FAILED(D3D12EnableExperimentalFeatures(1, &D3D12ComputeOnlyDevices, nullptr, 0));
-            }
+             // Check if adapter selected has DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX attribute selected. If so,
+             // then GPU was selected that has D3D12 and D3D11 capabilities. It would be the most stable to
+             // use DXGI to enumerate GPU and use D3D_FEATURE_LEVEL_11_0 so that image tensorization for
+             // video frames would be able to happen on the GPU.
+             if (spAdapter->IsDXAttributeSupported(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX))
+             {
+                 d3dFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0;
+                 com_ptr<IDXGIFactory4> dxgiFactory4;
+                 THROW_IF_FAILED(CreateDXGIFactory2(0, __uuidof(IDXGIFactory4), dxgiFactory4.put_void()));
 
-            // create D3D12Device
-            com_ptr<ID3D12Device> d3d12Device;
-            THROW_IF_FAILED(
-                D3D12CreateDevice(pAdapter, d3dFeatureLevel, __uuidof(ID3D12Device), d3d12Device.put_void()));
+                 // If DXGI factory creation was successful then get the IDXGIAdapter from the LUID acquired from the
+                 // selectedAdapter
+                 LUID adapterLuid;
+                 THROW_IF_FAILED(spAdapter->GetLUID(&adapterLuid));
+                 THROW_IF_FAILED(
+                     dxgiFactory4->EnumAdapterByLuid(adapterLuid, __uuidof(IDXGIAdapter), spDxgiAdapter.put_void()));
+                 pAdapter = spDxgiAdapter.get();
+             }
+             else
+             {
+                 // Need to enable experimental features to create D3D12 Device with adapter that has compute only
+                 // capabilities.
+                 THROW_IF_FAILED(D3D12EnableExperimentalFeatures(1, &D3D12ComputeOnlyDevices, nullptr, 0));
+             }
 
-            // create D3D12 command queue from device
-            com_ptr<ID3D12CommandQueue> d3d12CommandQueue;
-            D3D12_COMMAND_QUEUE_DESC commandQueueDesc = {};
-            commandQueueDesc.Type = commandQueueType;
-            THROW_IF_FAILED(d3d12Device->CreateCommandQueue(&commandQueueDesc, __uuidof(ID3D12CommandQueue),
-                                                            d3d12CommandQueue.put_void()));
+             // create D3D12Device
+             com_ptr<ID3D12Device> d3d12Device;
+             THROW_IF_FAILED(
+                 D3D12CreateDevice(pAdapter, d3dFeatureLevel, __uuidof(ID3D12Device), d3d12Device.put_void()));
 
-            // create LearningModelDevice from command queue
-            auto factory = get_activation_factory<LearningModelDevice, ILearningModelDeviceFactoryNative>();
-            com_ptr<::IUnknown> spUnkLearningModelDevice;
-            THROW_IF_FAILED(
-                factory->CreateFromD3D12CommandQueue(d3d12CommandQueue.get(), spUnkLearningModelDevice.put()));
-            session = LearningModelSession(model, spUnkLearningModelDevice.as<LearningModelDevice>());
-        }
+             // create D3D12 command queue from device
+             com_ptr<ID3D12CommandQueue> d3d12CommandQueue;
+             D3D12_COMMAND_QUEUE_DESC commandQueueDesc = {};
+             commandQueueDesc.Type = commandQueueType;
+             THROW_IF_FAILED(d3d12Device->CreateCommandQueue(&commandQueueDesc, __uuidof(ID3D12CommandQueue),
+                                                             d3d12CommandQueue.put_void()));
+
+             // create LearningModelDevice from command queue
+             auto factory = get_activation_factory<LearningModelDevice, ILearningModelDeviceFactoryNative>();
+             com_ptr<::IUnknown> spUnkLearningModelDevice;
+             THROW_IF_FAILED(
+                 factory->CreateFromD3D12CommandQueue(d3d12CommandQueue.get(), spUnkLearningModelDevice.put()));
+             session = LearningModelSession(model, spUnkLearningModelDevice.as<LearningModelDevice>());
+         }
 #endif
         else
         {

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -6,7 +6,6 @@
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 #include "Run.h"
 #include "Scenarios.h"
-
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
 std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningModel& model, const CommandLineArgs& args,
@@ -80,12 +79,12 @@ HRESULT BindInputFeatures(const LearningModel& model, const LearningModelBinding
     return S_OK;
 }
 
-HRESULT LoadModel(LearningModel &model, const std::wstring& path, bool capturePerf, OutputHelper& output, const CommandLineArgs& args,
-                        uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
+HRESULT LoadModel(LearningModel& model, const std::wstring& path, bool capturePerf, OutputHelper& output,
+                  const CommandLineArgs& args, uint32_t iterationNum, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     try
     {
-         output.PrintLoadingInfo(path);
+        output.PrintLoadingInfo(path);
         if (capturePerf)
         {
             WINML_PROFILING_START(profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
@@ -111,15 +110,18 @@ HRESULT LoadModel(LearningModel &model, const std::wstring& path, bool capturePe
     return S_OK;
 }
 
-HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevice, LearningModel& model, CommandLineArgs& args, OutputHelper& output,
-                      DeviceType deviceType, DeviceCreationLocation deviceCreationLocation,
-                      Profiler<WINML_MODEL_TEST_PERF>& profiler)
+HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevice, LearningModel& model,
+                      CommandLineArgs& args, OutputHelper& output, DeviceType deviceType,
+                      DeviceCreationLocation deviceCreationLocation, Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
     if (model == nullptr)
     {
         return hresult_invalid_argument().code();
     }
-
+#ifdef MCDM_BUILD
+    UINT adapterIndex = args.GetGPUAdapterIndex();
+    const std::wstring& adapterName = args.GetGPUAdapterName();
+#endif
     try
     {
         if (deviceCreationLocation == DeviceCreationLocation::UserD3DDevice && deviceType != DeviceType::CPU)
@@ -178,6 +180,126 @@ HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevic
                 WINML_PROFILING_STOP(profiler, WINML_MODEL_TEST_PERF::CREATE_SESSION);
             }
         }
+#ifdef MCDM_BUILD
+        else if ((TypeHelper::GetWinmlDeviceKind(deviceType) != LearningModelDeviceKind::Cpu) &&
+                 (!adapterName.empty() || adapterIndex != -1))
+        {
+             com_ptr<IDXCoreAdapterFactory> spFactory;
+             THROW_IF_FAILED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(spFactory.put())));
+
+             com_ptr<IDXCoreAdapterList> spAdapterList;
+             const GUID dxGUIDs[] = { DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
+
+             THROW_IF_FAILED(spFactory->GetAdapterList(dxGUIDs, ARRAYSIZE(dxGUIDs), spAdapterList.put()));
+
+             CHAR driverDescription[128];
+             std::map<int, com_ptr<IDXCoreAdapter>> validAdapters;
+             printf("Printing available adapters..\n");
+             for (UINT i = 0; i < spAdapterList->GetAdapterCount(); i++)
+             {
+                 com_ptr<IDXCoreAdapter> spAdapter;
+                 THROW_IF_FAILED(spAdapterList->GetItem(i, spAdapter.put()));
+                 // If the adapter is a software adapter then don't consider it
+                 bool isHardware;
+                 THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::IsHardware, sizeof(isHardware), &isHardware));
+                 if (isHardware)
+                 {
+                     THROW_IF_FAILED(spAdapter->QueryProperty(DXCoreProperty::DriverDescription,
+                                                              sizeof(driverDescription), driverDescription));
+                     printf("Index: %d, Description: %s\n", i, driverDescription);
+                     validAdapters[i] = spAdapter;
+                 }
+             }
+
+             com_ptr<IDXCoreAdapter> spAdapter = nullptr;
+             if (adapterIndex != -1) // Use index to retrieve adapter
+             {
+                 if (validAdapters.find(adapterIndex) != validAdapters.end())
+                 {
+                     spAdapter = validAdapters[adapterIndex];
+                 }
+                 else
+                 {
+                     throw hresult_invalid_argument(L"ERROR: No matching adapter with index provided: " + std::to_wstring(adapterIndex));
+                 }
+             }
+             else // Use name to retrieve adapter
+             {
+                 std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+                 for (auto it = validAdapters.begin(); it != validAdapters.end(); it++)
+                 {
+                     THROW_IF_FAILED(it->second->QueryProperty( DXCoreProperty::DriverDescription,
+                         sizeof(driverDescription), driverDescription));
+                     std::string driverDescriptionStr = std::string(driverDescription);
+                     std::string adapterNameStr = converter.to_bytes(adapterName);
+                     std::transform(driverDescriptionStr.begin(), driverDescriptionStr.end(),
+                                    driverDescriptionStr.begin(), ::tolower);
+                     std::transform(adapterNameStr.begin(), adapterNameStr.end(), adapterNameStr.begin(), ::tolower);
+                     if (strstr(driverDescriptionStr.c_str(), adapterNameStr.c_str()))
+                     {
+                         spAdapter = it->second;
+                         break;
+                     }
+                 }
+                 if (spAdapter == nullptr)
+                 {
+                     throw hresult_invalid_argument(L"ERROR: No matching adapter with given adapter name: " + adapterName);
+                 }
+             }
+             spAdapter->QueryProperty(DXCoreProperty::DriverDescription, sizeof(driverDescription),
+                                            driverDescription);
+             printf("Using adapter : %s\n", driverDescription);
+
+             IUnknown* pAdapter = spAdapter.get();
+             com_ptr<IDXGIAdapter> spDxgiAdapter;
+             D3D_FEATURE_LEVEL d3dFeatureLevel = D3D_FEATURE_LEVEL_1_0_CORE;
+             D3D12_COMMAND_LIST_TYPE commandQueueType = D3D12_COMMAND_LIST_TYPE_COMPUTE;
+
+             // Check if adapter selected has DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX attribute selected. If so,
+             // then GPU was selected that has D3D12 and D3D11 capabilities. It would be the most stable to
+             // use DXGI to enumerate GPU and use D3D_FEATURE_LEVEL_11_0 so that image tensorization for
+             // video frames would be able to happen on the GPU.
+             if (spAdapter->IsDXAttributeSupported(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRFX))
+             {
+                 d3dFeatureLevel = D3D_FEATURE_LEVEL::D3D_FEATURE_LEVEL_11_0;
+                 com_ptr<IDXGIFactory4> dxgiFactory4;
+                 THROW_IF_FAILED(CreateDXGIFactory2(0, __uuidof(IDXGIFactory4), dxgiFactory4.put_void()));
+
+                 // If DXGI factory creation was successful then get the IDXGIAdapter from the LUID acquired from the
+                 // selectedAdapter
+                 LUID adapterLuid;
+                 THROW_IF_FAILED(spAdapter->GetLUID(&adapterLuid));
+                 THROW_IF_FAILED(
+                     dxgiFactory4->EnumAdapterByLuid(adapterLuid, __uuidof(IDXGIAdapter), spDxgiAdapter.put_void()));
+                 pAdapter = spDxgiAdapter.get();
+             }
+             else
+             {
+                 // Need to enable experimental features to create D3D12 Device with adapter that has compute only
+                 // capabilities.
+                 THROW_IF_FAILED(D3D12EnableExperimentalFeatures(1, &D3D12ComputeOnlyDevices, nullptr, 0));
+             }
+
+             // create D3D12Device
+             com_ptr<ID3D12Device> d3d12Device;
+             THROW_IF_FAILED(
+                 D3D12CreateDevice(pAdapter, d3dFeatureLevel, __uuidof(ID3D12Device), d3d12Device.put_void()));
+
+             // create D3D12 command queue from device
+             com_ptr<ID3D12CommandQueue> d3d12CommandQueue;
+             D3D12_COMMAND_QUEUE_DESC commandQueueDesc = {};
+             commandQueueDesc.Type = commandQueueType;
+             THROW_IF_FAILED(d3d12Device->CreateCommandQueue(&commandQueueDesc, __uuidof(ID3D12CommandQueue),
+                                                             d3d12CommandQueue.put_void()));
+
+             // create LearningModelDevice from command queue
+             auto factory = get_activation_factory<LearningModelDevice, ILearningModelDeviceFactoryNative>();
+             com_ptr<::IUnknown> spUnkLearningModelDevice;
+             THROW_IF_FAILED(
+                 factory->CreateFromD3D12CommandQueue(d3d12CommandQueue.get(), spUnkLearningModelDevice.put()));
+             session = LearningModelSession(model, spUnkLearningModelDevice.as<LearningModelDevice>());
+        }
+#endif
         else
         {
             LearningModelDevice learningModelDevice(TypeHelper::GetWinmlDeviceKind(deviceType));
@@ -209,12 +331,14 @@ HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevic
     return S_OK;
 }
 
-HRESULT BindInputs(LearningModelBinding &context, const LearningModel& model, const LearningModelSession& session, OutputHelper& output,
-                   DeviceType deviceType, const CommandLineArgs& args, InputBindingType inputBindingType, InputDataType inputDataType,
-                   const IDirect3DDevice& winrtDevice, DeviceCreationLocation deviceCreationLocation, uint32_t iteration,
+HRESULT BindInputs(LearningModelBinding& context, const LearningModel& model, const LearningModelSession& session,
+                   OutputHelper& output, DeviceType deviceType, const CommandLineArgs& args,
+                   InputBindingType inputBindingType, InputDataType inputDataType, const IDirect3DDevice& winrtDevice,
+                   DeviceCreationLocation deviceCreationLocation, uint32_t iteration,
                    Profiler<WINML_MODEL_TEST_PERF>& profiler)
 {
-    if (deviceType == DeviceType::CPU && inputDataType == InputDataType::Tensor && inputBindingType == InputBindingType::GPU)
+    if (deviceType == DeviceType::CPU && inputDataType == InputDataType::Tensor &&
+        inputBindingType == InputBindingType::GPU)
     {
         std::cout << "Cannot create D3D12 device on client if CPU device type is selected." << std::endl;
         return E_INVALIDARG;
@@ -237,7 +361,6 @@ HRESULT BindInputs(LearningModelBinding &context, const LearningModel& model, co
         std::wcout << hr.message().c_str() << std::endl;
         return hr.code();
     }
-
 
     HRESULT bindInputResult =
         BindInputFeatures(model, context, inputFeatures, args, output, captureIterationPerf, iteration, profiler);
@@ -277,16 +400,16 @@ std::vector<std::wstring> GetModelsInDirectory(CommandLineArgs& args, OutputHelp
     return modelPaths;
 }
 
-
 HRESULT CheckIfModelAndConfigurationsAreSupported(LearningModel& model, const std::wstring& modelPath,
                                                   const DeviceType deviceType,
                                                   const std::vector<InputDataType>& inputDataTypes,
                                                   const std::vector<DeviceCreationLocation>& deviceCreationLocations)
 {
     // Does user want image as input binding
-    bool hasInputBindingImage = std::any_of(inputDataTypes.begin(), inputDataTypes.end(), [](const InputDataType inputDataType){
+    bool hasInputBindingImage =
+        std::any_of(inputDataTypes.begin(), inputDataTypes.end(), [](const InputDataType inputDataType) {
             return inputDataType == InputDataType::ImageBGR || inputDataType == InputDataType::ImageRGB;
-    });
+        });
 
     for (auto inputFeature : model.InputFeatures())
     {
@@ -345,7 +468,6 @@ HRESULT EvaluateModel(LearningModelEvaluationResult& result, const LearningModel
             if (args.IsPerIterationCapture())
             {
                 output.SaveEvalPerformance(profiler, iterationNum);
-
             }
         }
     }
@@ -496,18 +618,19 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
             ConcurrentLoadModel(modelPaths, args.NumThreads(), args.ThreadInterval(), true);
             return 0;
         }
-        for (const auto& path: modelPaths)
+        for (const auto& path : modelPaths)
         {
             LearningModel model = nullptr;
-    
-            LoadModel(model, path, args.IsPerformanceCapture() || args.IsPerIterationCapture(), output, args, 0, profiler);
+
+            LoadModel(model, path, args.IsPerformanceCapture() || args.IsPerIterationCapture(), output, args, 0,
+                      profiler);
             for (auto deviceType : deviceTypes)
             {
                 lastHr = CheckIfModelAndConfigurationsAreSupported(model, path, deviceType, inputDataTypes,
-                                                                     deviceCreationLocations);
+                                                                   deviceCreationLocations);
                 if (FAILED(lastHr))
                 {
-                  continue;
+                    continue;
                 }
                 for (auto deviceCreationLocation : deviceCreationLocations)
                 {
@@ -523,27 +646,28 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
                     LearningModelSession session = nullptr;
                     IDirect3DDevice winrtDevice = nullptr;
                     lastHr = CreateSession(session, winrtDevice, model, args, output, deviceType,
-                                               deviceCreationLocation, profiler);
+                                           deviceCreationLocation, profiler);
                     if (FAILED(lastHr))
                     {
                         continue;
                     }
                     for (auto inputDataType : inputDataTypes)
                     {
-                       for (auto inputBindingType : inputBindingTypes)
-                       {
-                           // Clear up bind, eval performance metrics after iteration
-                           if (args.IsPerformanceCapture() || args.IsPerIterationCapture())
-                           {
-                               // Resets all values from profiler for bind and evaluate.
-                               profiler.Reset(WINML_MODEL_TEST_PERF::BIND_VALUE, WINML_MODEL_TEST_PERF::COUNT);
-                           }
+                        for (auto inputBindingType : inputBindingTypes)
+                        {
+                            // Clear up bind, eval performance metrics after iteration
+                            if (args.IsPerformanceCapture() || args.IsPerIterationCapture())
+                            {
+                                // Resets all values from profiler for bind and evaluate.
+                                profiler.Reset(WINML_MODEL_TEST_PERF::BIND_VALUE, WINML_MODEL_TEST_PERF::COUNT);
+                            }
                             for (uint32_t i = 0; i < args.NumIterations(); i++)
                             {
 #if defined(_AMD64_)
                                 // PIX markers only work on AMD64
-                                // If PIX tool was attached then capture already began for the first iteration before session creation.
-                                // This is to begin PIX capture for each iteration after the first iteration.
+                                // If PIX tool was attached then capture already began for the first iteration before
+                                // session creation. This is to begin PIX capture for each iteration after the first
+                                // iteration.
                                 if (i > 0 && output.GetGraphicsAnalysis())
                                 {
                                     output.GetGraphicsAnalysis()->BeginCapture();
@@ -551,15 +675,15 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
 #endif
                                 LearningModelBinding context(session);
                                 lastHr = BindInputs(context, model, session, output, deviceType, args, inputBindingType,
-                                                inputDataType, winrtDevice, deviceCreationLocation, i, profiler);
+                                                    inputDataType, winrtDevice, deviceCreationLocation, i, profiler);
                                 if (FAILED(lastHr))
                                 {
                                     break;
                                 }
                                 LearningModelEvaluationResult result = nullptr;
                                 bool capture_perf = args.IsPerformanceCapture() || args.IsPerIterationCapture();
-                                lastHr = EvaluateModel(result, model, context, session, args, output,
-                                                   capture_perf, i, profiler);
+                                lastHr = EvaluateModel(result, model, context, session, args, output, capture_perf, i,
+                                                       profiler);
                                 if (FAILED(lastHr))
                                 {
                                     output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType,
@@ -605,7 +729,7 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
                                                                      deviceCreationLocationStringified);
                                 }
                             }
-                       }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This change adds back Dxcore to WinMLRunner.

- -GPUAdapterIndex <index number> : run model on GPU specified by its DXCore index. NOTE: Please only use this flag on DXCore supported machines.
- -GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines.

Examples:
- ./WinMLRunner -model ./SqueezeNet.onnx -GpuAdapterName vpu
- ./WinMLRunner -model ./SqueezeNet.onnx -GpuAdapterIndex 2