### PR TITLE
Update windows.foundation.h to collections headers specificially

### DIFF
--- a/Tools/WinMLRunner/src/Common.h
+++ b/Tools/WinMLRunner/src/Common.h
@@ -5,7 +5,7 @@
 // unknown.h needs to be inlcuded before any winrt headers
 #include <unknwn.h>
 #include <winrt/Windows.AI.MachineLearning.h>
-#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Media.h>


### PR DESCRIPTION
Issue: When we move ahead to a new windows sdk, this header no longer includes the windows.foundation.collections.h header, and will cause build breaks.

Fix: Bump forward to using the collections header now, as it will unblock moving forward the sdk.