### PR TITLE
User/orilevari/update nuget ado task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 | Sample/Tool | Status |
 |---------|--------------|
-| All Samples | [![Build Status](https://mscodehub.visualstudio.com/WindowsAI/_apis/build/status/winml/WinML%20Public%20Samples%20CI%20Build%20(Github-yml)?branchName=master)](https://mscodehub.visualstudio.com/WindowsAI/_build/latest?definitionId=612?branchName=master) |
-| WinmlRunner | [![Build status](https://mscodehub.visualstudio.com/DefaultCollection/WindowsAI/_apis/build/status/winml/WinML%20Dashboard%20CI%20Build)](https://mscodehub.visualstudio.com/DefaultCollection/WindowsAI/_build/latest?definitionId=602) |
+| All Samples | [![Build Status](https://microsoft.visualstudio.com/WindowsAI/_apis/build/status/WinML/Samples/Github%20Public%20Samples%20Build%20RS5?branchName=master)](https://microsoft.visualstudio.com/WindowsAI/_build/latest?definitionId=39302&branchName=master) |
+| WinmlRunner | [![Build Status](https://microsoft.visualstudio.com/WindowsAI/_apis/build/status/WInMLRunner%20CI%20Build?branchName=master)](https://microsoft.visualstudio.com/WindowsAI/_build/latest?definitionId=38654&branchName=master) |
 | WinML Dashboard | [![Build status](https://mscodehub.visualstudio.com/DefaultCollection/WindowsAI/_apis/build/status/winml/WinML%20Dashboard%20CI%20Build)](https://mscodehub.visualstudio.com/DefaultCollection/WindowsAI/_build/latest?definitionId=601) |
 
 

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -229,5 +229,5 @@ steps:
     displayName: 'Publish Artifact: Samples'
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: WinMLPublicSamples
+      artifactName: WinMLPublicSamples-RS5
     condition: succeededOrFailed()

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -64,7 +64,7 @@ steps:
       versionSpec: 4.9.2
     condition: succeededOrFailed()
 
-  - task: NuGetCommand@2
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore'
     condition: succeededOrFailed()
 

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -24,7 +24,7 @@ strategy:
       BuildConfiguration: Debug
 
 pool:
-  name: Package ES CodeHub Lab E
+  name: Package ES Lab E
 #  demands: agent.osversion -equals 10.0.17763
 
 # CI trigger


### PR DESCRIPTION
Various modifications to our build pipeline definition and README to support recent internal changes.
1) change nuget task to guid due to internal limitation
2) modify pool name for now available pool
3) update links for build status in README
4) update artifact name