### PR TITLE
move caption of debug output to top

### DIFF
--- a/Tools/WinMLDashboard/README.md
+++ b/Tools/WinMLDashboard/README.md
@@ -75,10 +75,10 @@ To debug your model follow these steps:
 
 <img src="./public/ConfigureDebug.png" width=800/>
 <img src="./public/DebugView.png" width=800/>
-<img src="./public/DebugPngs.png" width=800/>
 
 *Intermediate PNG convolutional output from an image of a [kitten](../../SharedContent/media/kitten_224.png)*
 
+<img src="./public/DebugPngs.png" width=800/>
 
 ## Install
 


### PR DESCRIPTION
moves caption in dashboard readme for debug output to above the image.