### PR TITLE
update all version information for dashboard to v0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For additional information on Windows ML, including step-by-step tutorials and h
 
 ## Developer Tools
 - **[WinML Dashboard (Preview)](https://github.com/Microsoft/Windows-Machine-Learning/tree/master/Tools/WinMLDashboard)**: a GUI-based tool for viewing, editing, converting, and validating machine learning models for Windows ML inference engine. 
-[Download Preview Version](https://github.com/Microsoft/Windows-Machine-Learning/releases/tag/0.5.1)
+[Download Preview Version](https://github.com/Microsoft/Windows-Machine-Learning/releases/tag/v0.6.1)
 
   <img src='./Tools/WinMLDashboard/public/EditorView2.PNG' width=800/>
 

--- a/Tools/WinMLDashboard/README.md
+++ b/Tools/WinMLDashboard/README.md
@@ -1,6 +1,6 @@
 # WinML Dashboard (preview)
 
-WinML Dashboard is a tool for **viewing**, **editing**, **converting**, and **validating** machine learning models for [Windows ML](https://docs.microsoft.com/en-us/windows/ai/) inference engine. The engine is built into Windows 10 and evaluates trained models locally on Windows devices using hardware optimizations for CPU and GPU to enable high performance inferences. [(Download Preview Version of the tool)](https://github.com/Microsoft/Windows-Machine-Learning/releases/tag/v0.5.1)   
+WinML Dashboard is a tool for **viewing**, **editing**, **converting**, and **validating** machine learning models for [Windows ML](https://docs.microsoft.com/en-us/windows/ai/) inference engine. The engine is built into Windows 10 and evaluates trained models locally on Windows devices using hardware optimizations for CPU and GPU to enable high performance inferences. [(Download Preview Version of the tool)](https://github.com/Microsoft/Windows-Machine-Learning/releases/tag/v0.6.1)   
 
 Today there are several different frameworks available for training and evaluating machine learning models, which makes it difficult for app developers to integate models into their product. Windows ML uses [ONNX](http://onnx.ai/) machine learning model format that allows conversion from one framework format to another, and this Dashboard makes it easy to convert models from different frameworks to ONNX. 
  

--- a/Tools/WinMLDashboard/build.js
+++ b/Tools/WinMLDashboard/build.js
@@ -9,9 +9,9 @@ resultPromise = electronInstaller.createWindowsInstaller({
     loadingGif: './public/progress_bar.gif',
     noMsi: true,
     outputDirectory: path.join('./installer'), 
-    setupExe: 'WinMLDashboard_setup_0.5.1.exe',
+    setupExe: 'WinMLDashboard_setup_0.6.1.exe',
     setupIcon: './public/winml_icon.ico',
-    version: '0.5.1',
+    version: '0.6.1',
   });
 
 // tslint:disable-next-line:no-console

--- a/Tools/WinMLDashboard/package.json
+++ b/Tools/WinMLDashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WinMLDashboard",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "icon": "public/winml_icon.ico",
   "description": "Dashboard for development in ONNX using Windows ML",
   "author": "Microsoft Corporation",

--- a/Tools/WinMLDashboard/public/about.html
+++ b/Tools/WinMLDashboard/public/about.html
@@ -13,7 +13,7 @@
     </div>
     <h3 class="title" > WinML DashBoard</h3>
     <div class="description">
-      <div class="Version">Version: 0.5.1 (prerelease)</div>
+      <div class="Version">Version: 0.6.1 (prerelease)</div>
       <div class="Commit">Commit: aa3bbca549ea85cb381095b075d62517cb3b541c</div>
       <div class="Date">Date: Oct 17, 2018</div>
       <div class="Architecture">Architecture: x64</div>


### PR DESCRIPTION
updates version info to 0.6.1.
The download link in the root readme previously was pointing to the wrong url so now that is fixed as well.