### PR TITLE
This change allows user to specify folder of images to bind and evaluate

### DIFF
--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -650,7 +650,7 @@ namespace WinMLRunnerTest
 
             std::vector<std::string> images = { "fish.png", "kitten_224.png" };
 
-            // Copy models from list to test_folder_input
+            // Copy images from list to test_folder_input
             for (auto image : images)
             {
                 std::string copyCommand = "Copy ";

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -221,21 +221,21 @@ namespace WinMLRunnerTest
     }
 
     TEST_CLASS(GarbageInputTest) { public: TEST_CLASS_INITIALIZE(SetupClass) {
-            // Make test_folder_input folder before starting the tests
-            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(mkFolderCommand.c_str());
+    // Make test_folder_input folder before starting the tests
+    std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+    system(mkFolderCommand.c_str());
 
-            std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
+    std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
 
-            // Copy models from list to test_folder_input
-            for (auto model : models)
-            {
-                std::string copyCommand = "Copy ";
-                copyCommand += model;
-                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-                system(copyCommand.c_str());
-            }
-        } // namespace WinMLRunnerTest
+    // Copy models from list to test_folder_input
+    for (auto model : models)
+    {
+        std::string copyCommand = "Copy ";
+        copyCommand += model;
+        copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+        system(copyCommand.c_str());
+    }
+} // namespace WinMLRunnerTest
 
         TEST_CLASS_CLEANUP(CleanupClass)
         {
@@ -520,30 +520,8 @@ namespace WinMLRunnerTest
     TEST_CLASS(ImageInputTest)
     {
     public:
-        TEST_CLASS_INITIALIZE(SetupClass)
-        {
-            // Make test_folder_input folder before starting the tests
-            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(mkFolderCommand.c_str());
-
-            std::vector<std::string> models = { "fish.png", "kitten_224.png"};
-
-            // Copy models from list to test_folder_input
-            for (auto model : models)
-            {
-                std::string copyCommand = "Copy ";
-                copyCommand += model;
-                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-                system(copyCommand.c_str());
-            }
-        }
-
         TEST_METHOD_CLEANUP(CleanupMethod)
         {
-            std::string copyCommand = "rd /s /q ";
-            copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(copyCommand.c_str());
-
             // Remove output.csv after each test
             // TODO: this will not work if each test runs in parallel. Use different file path for each test, and clean up at class setup
             std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
@@ -662,12 +640,6 @@ namespace WinMLRunnerTest
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount(tensorDataPath + L"\\PerIterationData\\Summary.csv"));
-        }
-
-        TEST_METHOD(ProvidedImageInputFolder)
-        {
-            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", L"SqueezeNet.onnx", L"-InputImageFolder", INPUT_FOLDER_PATH});
-            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
         }
     };
 
@@ -801,12 +773,6 @@ namespace WinMLRunnerTest
             }
         }
 
-        TEST_CLASS_CLEANUP(CleanupClass)
-        {
-            std::string copyCommand = "rd /s /q ";
-            copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-            system(copyCommand.c_str());
-        }
         TEST_METHOD(RunFolder)
         {
             const std::wstring command = BuildCommand({

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -641,6 +641,30 @@ namespace WinMLRunnerTest
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount(tensorDataPath + L"\\PerIterationData\\Summary.csv"));
         }
+
+        TEST_METHOD(ProvidedImageInputFolder)
+        {
+            // Make test_folder_input folder before starting the tests
+            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(mkFolderCommand.c_str());
+
+            std::vector<std::string> images = { "fish.png", "kitten_224.png" };
+
+            // Copy models from list to test_folder_input
+            for (auto image : images)
+            {
+                std::string copyCommand = "Copy ";
+                copyCommand += image;
+                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+                system(copyCommand.c_str());
+            }
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", L"SqueezeNet.onnx", L"-InputImageFolder", INPUT_FOLDER_PATH });
+            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
+
+            std::string removeCommand = "rd /s /q ";
+            removeCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(removeCommand.c_str());
+        }
     };
 
     TEST_CLASS(CsvInputTest)

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -220,9 +220,7 @@ namespace WinMLRunnerTest
         return true;
     }
 
-    TEST_CLASS(GarbageInputTest) { 
-    public: 
-        TEST_CLASS_INITIALIZE(SetupClass) {
+    TEST_CLASS(GarbageInputTest) { public: TEST_CLASS_INITIALIZE(SetupClass) {
             // Make test_folder_input folder before starting the tests
             std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
             system(mkFolderCommand.c_str());

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -220,22 +220,24 @@ namespace WinMLRunnerTest
         return true;
     }
 
-    TEST_CLASS(GarbageInputTest) { public: TEST_CLASS_INITIALIZE(SetupClass) {
-    // Make test_folder_input folder before starting the tests
-    std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-    system(mkFolderCommand.c_str());
+    TEST_CLASS(GarbageInputTest) { 
+    public: 
+        TEST_CLASS_INITIALIZE(SetupClass) {
+            // Make test_folder_input folder before starting the tests
+            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(mkFolderCommand.c_str());
 
-    std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
+            std::vector<std::string> models = { "SqueezeNet.onnx", "keras_Add_ImageNet_small.onnx" };
 
-    // Copy models from list to test_folder_input
-    for (auto model : models)
-    {
-        std::string copyCommand = "Copy ";
-        copyCommand += model;
-        copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
-        system(copyCommand.c_str());
-    }
-} // namespace WinMLRunnerTest
+            // Copy models from list to test_folder_input
+            for (auto model : models)
+            {
+                std::string copyCommand = "Copy ";
+                copyCommand += model;
+                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+                system(copyCommand.c_str());
+            }
+        } // namespace WinMLRunnerTest
 
         TEST_CLASS_CLEANUP(CleanupClass)
         {
@@ -520,8 +522,30 @@ namespace WinMLRunnerTest
     TEST_CLASS(ImageInputTest)
     {
     public:
-        TEST_METHOD_CLEANUP(CleanupMethod)
+        TEST_CLASS_INITIALIZE(SetupClass)
         {
+            // Make test_folder_input folder before starting the tests
+            std::string mkFolderCommand = "mkdir " + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(mkFolderCommand.c_str());
+
+            std::vector<std::string> models = { "fish.png", "kitten_224.png"};
+
+            // Copy models from list to test_folder_input
+            for (auto model : models)
+            {
+                std::string copyCommand = "Copy ";
+                copyCommand += model;
+                copyCommand += ' ' + std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+                system(copyCommand.c_str());
+            }
+        }
+
+        TEST_CLASS_CLEANUP(CleanupClass)
+        {
+            std::string copyCommand = "rd /s /q ";
+            copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(copyCommand.c_str());
+
             // Remove output.csv after each test
             // TODO: this will not work if each test runs in parallel. Use different file path for each test, and clean up at class setup
             std::remove(std::string(OUTPUT_PATH.begin(), OUTPUT_PATH.end()).c_str());
@@ -640,6 +664,12 @@ namespace WinMLRunnerTest
 
             // We need to expect one more line because of the header
             Assert::AreEqual(static_cast<size_t>(2), GetOutputCSVLineCount(tensorDataPath + L"\\PerIterationData\\Summary.csv"));
+        }
+
+        TEST_METHOD(ProvidedImageInputFolder)
+        {
+            const std::wstring command = BuildCommand({ EXE_PATH, L"-model", L"SqueezeNet.onnx", L"-InputImageFolder", INPUT_FOLDER_PATH});
+            Assert::AreEqual(S_OK, RunProc((wchar_t*)command.c_str()));
         }
     };
 
@@ -773,6 +803,12 @@ namespace WinMLRunnerTest
             }
         }
 
+        TEST_CLASS_CLEANUP(CleanupClass)
+        {
+            std::string copyCommand = "rd /s /q ";
+            copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());
+            system(copyCommand.c_str());
+        }
         TEST_METHOD(RunFolder)
         {
             const std::wstring command = BuildCommand({

--- a/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
+++ b/Testing/WinMLRunnerTest/WinMLRunnerTest.cpp
@@ -538,7 +538,7 @@ namespace WinMLRunnerTest
             }
         }
 
-        TEST_CLASS_CLEANUP(CleanupClass)
+        TEST_METHOD_CLEANUP(CleanupMethod)
         {
             std::string copyCommand = "rd /s /q ";
             copyCommand += std::string(INPUT_FOLDER_PATH.begin(), INPUT_FOLDER_PATH.end());

--- a/Tools/WinMLRunner/README.md
+++ b/Tools/WinMLRunner/README.md
@@ -45,7 +45,8 @@ Required command-Line arguments:
 -Tensor : load the input as a tensor
 -Perf [all]: capture performance measurements such as timing and memory usage. Specifying "all" will output all measurements
 -Iterations : # times perf measurements will be run/averaged. (maximum: 1024 times)
--Input <fully qualified path>: binds image or CSV to model
+-Input <path to input file>: binds image or CSV to model
+-InputImageFolder <path to directory of images> : specify folder of images to bind to model" << std::endl;
 -TopK <number>: print top <number> values in the result. Default to 1
 -BaseOutputPath [<fully qualified path>] : base output directory path for results, default to cwd
 -PerfOutput [<path>] : fully qualified or relative path including csv filename for perf results

--- a/Tools/WinMLRunner/src/BindingUtilities.h
+++ b/Tools/WinMLRunner/src/BindingUtilities.h
@@ -477,8 +477,8 @@ namespace BindingUtilities
         }
         else if (args.IsImageInput())
         {
-            // Creating Tensors for Input Images haven't been added yet.
-            throw hresult_not_implemented(L"Creating Tensors for Input Images haven't been implemented yet!");
+            // Creating Tensors for Input Images haven't been added.
+            throw hresult_not_implemented(L"Creating Tensors for Input Images haven't been implemented!");
         }
 
         if (inputBindingType == InputBindingType::CPU)
@@ -605,7 +605,7 @@ namespace BindingUtilities
             }
             else
             {
-                throw hresult_not_implemented(L"BitmapPixel format not yet handled by WinMLRunner.");
+                throw hresult_not_implemented(L"BitmapPixel format not handled by WinMLRunner.");
             }
             std::vector<int64_t> shape = { 1, channels, imageFeatureDescriptor.Height(),
                                            imageFeatureDescriptor.Width() };

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -36,6 +36,7 @@ void CommandLineArgs::PrintUsage()
               << std::endl;
     std::cout << "  -Iterations : # times perf measurements will be run/averaged. (maximum: 1024 times)" << std::endl;
     std::cout << "  -Input <fully qualified path> : binds image or CSV to model" << std::endl;
+    std::cout << "  -InputImageFolder <fully qualified path> : folder of images to bind to model" << std::endl;
     std::cout << "  -TopK <number> : print top <number> values in the result. Default to 1" << std::endl;
     std::cout << "  -BaseOutputPath [<fully qualified path>] : base output directory path for results, default to cwd"
               << std::endl;
@@ -139,7 +140,13 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
         }
         else if ((_wcsicmp(args[i].c_str(), L"-Input") == 0))
         {
+            CheckNextArgument(args, i);
             m_inputData = args[++i];
+        }
+        else if ((_wcsicmp(args[i].c_str(), L"-InputImageFolder") == 0))
+        {
+            CheckNextArgument(args, i);
+            m_inputImageFolderPath = args[++i];
         }
         else if ((_wcsicmp(args[i].c_str(), L"-PerfOutput") == 0))
         {
@@ -326,7 +333,7 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
         if (m_inputData.find(L".png") != std::string::npos || m_inputData.find(L".jpg") != std::string::npos ||
             m_inputData.find(L".jpeg") != std::string::npos)
         {
-            m_imagePath = m_inputData;
+            m_imagePaths.push_back(m_inputData);
         }
         else if (m_inputData.find(L".csv") != std::string::npos)
         {
@@ -339,10 +346,29 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
             throw hresult_invalid_argument(msg.c_str());
         }
     }
-
+    if (!m_inputImageFolderPath.empty())
+    {
+        PopulateInputImagePaths();
+    }
     SetupOutputDirectories(sBaseOutputPath, sPerfOutputPath, sPerIterationDataPath);
 
     CheckForInvalidArguments();
+}
+
+void CommandLineArgs::PopulateInputImagePaths()
+{
+    for (auto& it : std::filesystem::directory_iterator(m_inputImageFolderPath))
+    {
+        std::string path = it.path().string();
+        if (it.path().string().find(".png") != std::string::npos ||
+            it.path().string().find(".jpg") != std::string::npos ||
+            it.path().string().find(".jpeg") != std::string::npos)
+        {
+            std::wstring fileName;
+            fileName.assign(path.begin(), path.end());
+            m_imagePaths.push_back(fileName);
+        }
+    }
 }
 
 void CommandLineArgs::SetupOutputDirectories(const std::wstring& sBaseOutputPath,

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <iomanip>
 #include <filesystem>
+#include "Filehelper.h"
 
 using namespace Windows::AI::MachineLearning;
 
@@ -141,12 +142,12 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
         else if ((_wcsicmp(args[i].c_str(), L"-Input") == 0))
         {
             CheckNextArgument(args, i);
-            m_inputData = args[++i];
+            m_inputData = FileHelper::GetAbsolutePath(args[++i]);
         }
         else if ((_wcsicmp(args[i].c_str(), L"-InputImageFolder") == 0))
         {
             CheckNextArgument(args, i);
-            m_inputImageFolderPath = args[++i];
+            m_inputImageFolderPath = FileHelper::GetAbsolutePath(args[++i]);
         }
         else if ((_wcsicmp(args[i].c_str(), L"-PerfOutput") == 0))
         {
@@ -445,5 +446,9 @@ void CommandLineArgs::CheckForInvalidArguments()
     if (IsGarbageInput() && IsSaveTensor())
     {
         throw hresult_invalid_argument(L"Cannot save tensor output if no input data is provided!");
+    }
+    if (m_imagePaths.size() > 1 && IsSaveTensor())
+    {
+        throw hresult_not_implemented(L"Saving tensor output for multiple images isn't implemented yet.");
     }
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -449,6 +449,6 @@ void CommandLineArgs::CheckForInvalidArguments()
     }
     if (m_imagePaths.size() > 1 && IsSaveTensor())
     {
-        throw hresult_not_implemented(L"Saving tensor output for multiple images isn't implemented yet.");
+        throw hresult_not_implemented(L"Saving tensor output for multiple images isn't implemented.");
     }
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -36,8 +36,8 @@ void CommandLineArgs::PrintUsage()
                  "will output all measurements"
               << std::endl;
     std::cout << "  -Iterations : # times perf measurements will be run/averaged. (maximum: 1024 times)" << std::endl;
-    std::cout << "  -Input <fully qualified path> : binds image or CSV to model" << std::endl;
-    std::cout << "  -InputImageFolder <fully qualified path> : folder of images to bind to model" << std::endl;
+    std::cout << "  -Input <path to input file>: binds image or CSV to model" << std::endl;
+    std::cout << "  -InputImageFolder <path to directory of images> : specify folder of images to bind to model" << std::endl;
     std::cout << "  -TopK <number> : print top <number> values in the result. Default to 1" << std::endl;
     std::cout << "  -BaseOutputPath [<fully qualified path>] : base output directory path for results, default to cwd"
               << std::endl;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -25,6 +25,7 @@ public:
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
 
     const std::wstring& ImagePath() const { return m_imagePath; }
+    const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
@@ -72,8 +73,8 @@ public:
         // When there is no image or csv input provided, then garbage input binding is used.
         return m_imagePath.empty() && m_csvData.empty();
     }
-    bool IsCSVInput() const { return m_imagePath.empty() && !m_csvData.empty(); }
-    bool IsImageInput() const { return !m_imagePath.empty() && m_csvData.empty(); }
+    bool IsCSVInput() const { return m_imagePaths.empty() && !m_csvData.empty(); }
+    bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
 
     uint32_t NumIterations() const { return m_numIterations; }
     uint32_t NumThreads() const { return m_numThreads; }
@@ -143,6 +144,8 @@ private:
 
     std::wstring m_modelFolderPath;
     std::wstring m_modelPath;
+    std::vector<std::wstring> m_imagePaths;
+    std::wstring m_inputImageFolderPath;
     std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
@@ -161,4 +164,5 @@ private:
     void CheckForInvalidArguments();
     void SetupOutputDirectories(const std::wstring& sBaseOutputPath, const std::wstring& sPerfOutputPath,
                                 const std::wstring& sPerIterationDataPath);
+    void PopulateInputImagePaths();
 };

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -24,7 +24,6 @@ public:
 
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
 
-    const std::wstring& ImagePath() const { return m_imagePath; }
     const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
@@ -39,7 +38,7 @@ public:
     bool UseRGB() const
     {
         // If an image is specified without flags, we load it as a BGR image by default
-        return m_useRGB || (!m_imagePath.empty() && !m_useBGR && !m_useTensor);
+        return m_useRGB || (!m_imagePaths.empty() && !m_useBGR && !m_useTensor);
     }
 
     bool UseTensor() const
@@ -71,7 +70,7 @@ public:
     bool IsGarbageInput() const
     {
         // When there is no image or csv input provided, then garbage input binding is used.
-        return m_imagePath.empty() && m_csvData.empty();
+        return m_imagePaths.empty() && m_csvData.empty();
     }
     bool IsCSVInput() const { return m_imagePaths.empty() && !m_csvData.empty(); }
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
@@ -146,7 +145,6 @@ private:
     std::wstring m_modelPath;
     std::vector<std::wstring> m_imagePaths;
     std::wstring m_inputImageFolderPath;
-    std::wstring m_imagePath;
     std::wstring m_csvData;
     std::wstring m_inputData;
 #ifdef DXCORE_SUPPORTED_BUILD

--- a/Tools/WinMLRunner/src/Filehelper.cpp
+++ b/Tools/WinMLRunner/src/Filehelper.cpp
@@ -22,4 +22,15 @@ namespace FileHelper
 
         return val;
     }
+    std::wstring GetAbsolutePath(std::wstring relativePath)
+    {
+        TCHAR** lppPart = { NULL };
+        wchar_t absolutePath[MAX_PATH] = { 0 };
+        errno_t err = GetFullPathName(relativePath.c_str(), MAX_PATH, absolutePath, lppPart);
+        if (err == 0)
+        {
+            throw HRESULT_FROM_WIN32(GetLastError());
+        }
+        return absolutePath;
+    }
 } // namespace FileHelper

--- a/Tools/WinMLRunner/src/Filehelper.h
+++ b/Tools/WinMLRunner/src/Filehelper.h
@@ -4,4 +4,5 @@
 namespace FileHelper
 {
     std::wstring GetModulePath();
+    std::wstring GetAbsolutePath(std::wstring relativePath);
 }

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -578,7 +578,7 @@ public:
 
     void SetCSVFileName(const std::wstring& fileName) { m_csvFileName = fileName; }
 
-    void WritePerIterationPerformance(const CommandLineArgs& args, std::wstring model)
+    void WritePerIterationPerformance(const CommandLineArgs& args, const std::wstring model, const std::wstring imagePath)
     {
         if (m_csvFileNamePerIterationSummary.length() > 0)
         {
@@ -599,7 +599,7 @@ public:
             std::string modelName = converter.to_bytes(model);
             std::string fileNameResultDevice = converter.to_bytes(m_fileNameResultDevice);
             std::string inputName = args.IsCSVInput() ? converter.to_bytes(args.CsvPath())
-                                                      : args.IsImageInput() ? converter.to_bytes(args.ImagePath()) : "";
+                                                      : args.IsImageInput() ? converter.to_bytes(imagePath) : "";
 
             if (bNewFile)
             {

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -15,7 +15,10 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningMode
                                                               const std::wstring& imagePath)
 {
     std::vector<ILearningModelFeatureValue> inputFeatures;
-
+    if (!imagePath.empty())
+    {
+        std::wcout << L"Generating input feature(s) with image: " << imagePath << std::endl;
+    }
     for (uint32_t i = 0; i < model.InputFeatures().Size(); i++)
     {
         auto&& description = model.InputFeatures().GetAt(i);
@@ -506,12 +509,6 @@ HRESULT EvaluateModel(LearningModelEvaluationResult& result, const LearningModel
         std::wcout << hr.message().c_str() << std::endl;
         return hr.code();
     }
-
-    // Only print eval results on the first iteration, iff it's not garbage data
-    if (!args.IsGarbageInput() || args.IsSaveTensor())
-    {
-        BindingUtilities::PrintOrSaveEvaluationResults(model, args, result.Outputs(), output, iterationNum);
-    }
     return S_OK;
 }
 
@@ -675,6 +672,13 @@ void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModel
         {
             output.PrintEvaluatingInfo(i + 1, deviceType, inputBindingType, inputDataType, deviceCreationLocation,
                                        "[SUCCESS]");
+
+            // Only print eval results on the first iteration, iff it's not garbage data
+            if (!args.IsGarbageInput() || args.IsSaveTensor())
+            {
+                BindingUtilities::PrintOrSaveEvaluationResults(model, args, result.Outputs(), output, i);
+            }
+
             if (args.TerseOutput() && args.NumIterations() > 1)
             {
                 printf("Binding and Evaluating %d more time%s...", args.NumIterations() - 1,
@@ -705,7 +709,7 @@ void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModel
 
     if (SUCCEEDED(lastHr) && args.IsPerIterationCapture())
     {
-        output.WritePerIterationPerformance(args, model.Name().c_str());
+        output.WritePerIterationPerformance(args, model.Name().c_str(), imagePath);
     }
 }
 
@@ -812,8 +816,10 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
                             }
                             else
                             {
+                                const std::wstring& inputImagePath = L"";
                                 RunConfiguration(args, output, session, lastHr, model, deviceType, inputBindingType,
-                                             inputDataType, winrtDevice, deviceCreationLocation, profiler, path, nullptr);
+                                                 inputDataType, winrtDevice, deviceCreationLocation, profiler, path,
+                                                 L"");
                             }
                        }
                     }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -15,7 +15,7 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningMode
                                                               const std::wstring& imagePath)
 {
     std::vector<ILearningModelFeatureValue> inputFeatures;
-    if (!imagePath.empty())
+    if (!imagePath.empty() && (!args.TerseOutput() || args.TerseOutput() && iterationNum == 0))
     {
         std::wcout << L"Generating input feature(s) with image: " << imagePath << std::endl;
     }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -448,7 +448,7 @@ HRESULT CheckIfModelAndConfigurationsAreSupported(LearningModel& model, const st
         if (inputFeature.Kind() != LearningModelFeatureKind::Tensor &&
             inputFeature.Kind() != LearningModelFeatureKind::Image)
         {
-            std::wcout << L"Model: " + modelPath + L" has an input type that isn't supported by WinMLRunner yet."
+            std::wcout << L"Model: " + modelPath + L" has an input type that isn't supported by WinMLRunner."
                        << std::endl;
             return E_NOTIMPL;
         }


### PR DESCRIPTION
New flag: -InputImageFolder

 .\WinMLRunner.exe -model .\SqueezeNet.onnx -inputimagefolder .\images\

Also this change allows relative paths for specifying path to all inputs 