### PR TITLE
add include statement for windows.foundation.collection.h to fix build against newer windows sdk

### DIFF
--- a/Samples/AdapterSelection/AdapterSelection/cpp/pch.h
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/pch.h
@@ -14,6 +14,7 @@
 #include <windows.h>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Storage.h>

--- a/Samples/CustomOperatorCPU/desktop/cpp/pch.h
+++ b/Samples/CustomOperatorCPU/desktop/cpp/pch.h
@@ -14,6 +14,7 @@
 #include <winstring.h>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Storage.h>

--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/pch.h
@@ -12,6 +12,7 @@
 #include <windows.h>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.AI.MachineLearning.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Storage.h>


### PR DESCRIPTION
A break in the build was introduced on newer windows SDK versions. Adding these include statements fix them.