### PR TITLE
Allow multiple iterations for load and session creation and initial bind and evaluate in winmlrunner static library

### DIFF
--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -102,7 +102,7 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
             m_useGPUMinPower = true;
         }
 #ifdef DXCORE_SUPPORTED_BUILD
-        else if ((_wcsicmp(args[i].c_str(), L"-GPUAdapterName") == 0) || (_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0))
+        else if (_wcsicmp(args[i].c_str(), L"-GPUAdapterName") == 0)
         {
             CheckNextArgument(args, i);
             HMODULE library = nullptr;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -76,6 +76,8 @@ public:
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
 
     uint32_t NumIterations() const { return m_numIterations; }
+    uint32_t NumLoadIterations() const { return m_numLoadIterations; }
+    uint32_t NumSessionCreationIterations() const { return m_numSessionIterations; }
     double IterationTimeLimit() const { return m_iterationTimeLimitMilliseconds; }
     uint32_t NumThreads() const { return m_numThreads; }
     uint32_t ThreadInterval() const { return m_threadInterval; } // Thread interval in milliseconds
@@ -111,6 +113,8 @@ public:
     void SetTopK(unsigned k) { m_topK = k; }
     void SetPerformanceCSVPath(const std::wstring& performanceCSVPath) { m_perfOutputPath = performanceCSVPath; }
     void SetRunIterations(const uint32_t iterations) { m_numIterations = iterations; }
+    void SetSessionCreationIterations(const uint32_t iterations) { m_numSessionIterations = iterations; }
+    void SetLoadIterations(const uint32_t iterations) { m_numLoadIterations = iterations; }
     void AddPerformanceFileMetadata(const std::string& key, const std::string& value)
     {
         m_perfFileMetadata.push_back(std::make_pair(key, value));
@@ -161,6 +165,8 @@ private:
     std::wstring m_perfOutputPath;
     std::wstring m_perIterationDataPath;
     uint32_t m_numIterations = 1;
+    uint32_t m_numLoadIterations = 1;
+    uint32_t m_numSessionIterations = 1;
     double m_iterationTimeLimitMilliseconds = 0;
     uint32_t m_numThreads = 1;
     uint32_t m_threadInterval = 0;

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -545,7 +545,7 @@ public:
     }
     void SaveEvalPerformance(Profiler<WINML_MODEL_TEST_PERF>& profiler, uint32_t iterNum)
     {
-        enum WINML_MODEL_TEST_PERF eval = (iterNum == 0)? EVAL_MODEL_FIRST_RUN: EVAL_MODEL;
+        enum WINML_MODEL_TEST_PERF eval = (iterNum == 0) ? EVAL_MODEL_FIRST_RUN : EVAL_MODEL;
         m_clockEvalTimes[iterNum] = profiler[eval].GetClockTime();
         m_CPUWorkingDiff[iterNum] = profiler[eval].GetCpuWorkingDiff();
         m_CPUWorkingStart[iterNum] = profiler[eval].GetCpuWorkingStart();
@@ -602,7 +602,8 @@ public:
 
     void SetCSVFileName(const std::wstring& fileName) { m_csvFileName = fileName; }
 
-    void WritePerIterationPerformance(const CommandLineArgs& args, const std::wstring model, const std::wstring imagePath)
+    void WritePerIterationPerformance(const CommandLineArgs& args, const std::wstring model,
+                                      const std::wstring imagePath)
     {
         if (m_csvFileNamePerIterationSummary.length() > 0)
         {
@@ -714,8 +715,7 @@ public:
 
     template <typename T>
     void ProcessTensorResult(const CommandLineArgs& args, const void* buffer, const uint32_t uCapacity,
-                             std::vector<std::pair<float,int>>& maxValues, std::ofstream& fout,
-                             unsigned int k)
+                             std::vector<std::pair<float, int>>& maxValues, std::ofstream& fout, unsigned int k)
     {
         // Create a priority queue of size k that pops the lowest value first
         // We will remove lowest values as we iterate over all the values
@@ -767,72 +767,158 @@ public:
     void WritePerformanceDataToCSV(const Profiler<WINML_MODEL_TEST_PERF>& profiler, int numIterations,
                                    std::wstring model, const std::string& deviceType, const std::string& inputBinding,
                                    const std::string& inputType, const std::string& deviceCreationLocation,
-                                   const std::vector<std::pair<std::string,std::string>>& perfFileMetadata) const
+                                   const std::vector<std::pair<std::string, std::string>>& perfFileMetadata) const
     {
-        double loadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
-        double createSessionTime = profiler[CREATE_SESSION].GetAverage(CounterType::TIMER);
+        double averageLoadTime = profiler[LOAD_MODEL].GetAverage(CounterType::TIMER);
+        double stdevLoadTime = profiler[LOAD_MODEL].GetStdev(CounterType::TIMER);
+        double minLoadTime = profiler[LOAD_MODEL].GetMin(CounterType::TIMER);
+        double maxLoadTime = profiler[LOAD_MODEL].GetMax(CounterType::TIMER);
+        uint32_t numberLoadIterations = profiler[LOAD_MODEL].GetCount();
+
+        double averageCreateSessionTime = profiler[CREATE_SESSION].GetAverage(CounterType::TIMER);
+        double stdevCreateSessionTime = profiler[CREATE_SESSION].GetStdev(CounterType::TIMER);
+        double minCreateSessionTime = profiler[CREATE_SESSION].GetMin(CounterType::TIMER);
+        double maxCreateSessionTime = profiler[CREATE_SESSION].GetMax(CounterType::TIMER);
+        uint32_t numberCreateSessionIterations = profiler[CREATE_SESSION].GetCount();
 
         double averageBindTime = profiler[BIND_VALUE].GetAverage(CounterType::TIMER);
         double stdevBindTime = profiler[BIND_VALUE].GetStdev(CounterType::TIMER);
         double minBindTime = profiler[BIND_VALUE].GetMin(CounterType::TIMER);
         double maxBindTime = profiler[BIND_VALUE].GetMax(CounterType::TIMER);
-        double firstBindTime = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::TIMER);
+
+        double averageFirstBindTime = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::TIMER);
+        double stdevFirstBindTime = profiler[BIND_VALUE_FIRST_RUN].GetStdev(CounterType::TIMER);
+        double minFirstBindTime = profiler[BIND_VALUE_FIRST_RUN].GetMin(CounterType::TIMER);
+        double maxFirstBindTime = profiler[BIND_VALUE_FIRST_RUN].GetMax(CounterType::TIMER);
 
         double averageEvalTime = profiler[EVAL_MODEL].GetAverage(CounterType::TIMER);
         double stdevEvalTime = profiler[EVAL_MODEL].GetStdev(CounterType::TIMER);
         double minEvalTime = profiler[EVAL_MODEL].GetMin(CounterType::TIMER);
         double maxEvalTime = profiler[EVAL_MODEL].GetMax(CounterType::TIMER);
-        double firstEvalTime = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::TIMER);
 
-        double firstLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double averageFirstEvalTime = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::TIMER);
+        double stdevFirstEvalTime = profiler[EVAL_MODEL_FIRST_RUN].GetStdev(CounterType::TIMER);
+        double minFirstEvalTime = profiler[EVAL_MODEL_FIRST_RUN].GetMin(CounterType::TIMER);
+        double maxFirstEvalTime = profiler[EVAL_MODEL_FIRST_RUN].GetMax(CounterType::TIMER);
 
-        double firstSessionCreationWorkingSetMemoryUsage =
+        double averageLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetStdev(CounterType::WORKING_SET_USAGE);
+        double minLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetMin(CounterType::WORKING_SET_USAGE);
+        double maxLoadWorkingSetMemoryUsage = profiler[LOAD_MODEL].GetMax(CounterType::WORKING_SET_USAGE);
+
+        double averageCreateSessionWorkingSetMemoryUsage =
             profiler[CREATE_SESSION].GetAverage(CounterType::WORKING_SET_USAGE);
-        double firstSessionCreationSharedMemoryUsage =
-            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstSessionCreationDedicatedMemoryUsage =
+        double stdevCreateSessionWorkingSetMemoryUsage =
+            profiler[CREATE_SESSION].GetStdev(CounterType::WORKING_SET_USAGE);
+        double minCreateSessionWorkingSetMemoryUsage = profiler[CREATE_SESSION].GetMin(CounterType::WORKING_SET_USAGE);
+        double maxCreateSessionWorkingSetMemoryUsage = profiler[CREATE_SESSION].GetMax(CounterType::WORKING_SET_USAGE);
+
+        double averageBindWorkingSetMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevBindWorkingSetMemoryUsage = profiler[BIND_VALUE].GetStdev(CounterType::WORKING_SET_USAGE);
+        double minBindWorkingSetMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::WORKING_SET_USAGE);
+        double maxBindWorkingSetMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::WORKING_SET_USAGE);
+
+        double averageFirstBindWorkingSetMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevFirstBindWorkingSetMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetStdev(CounterType::WORKING_SET_USAGE);
+        double minFirstBindWorkingSetMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetMin(CounterType::WORKING_SET_USAGE);
+        double maxFirstBindWorkingSetMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetMax(CounterType::WORKING_SET_USAGE);
+
+        double averageEvalWorkingSetMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevEvalWorkingSetMemoryUsage = profiler[EVAL_MODEL].GetStdev(CounterType::WORKING_SET_USAGE);
+        double minEvalWorkingSetMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::WORKING_SET_USAGE);
+        double maxEvalWorkingSetMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::WORKING_SET_USAGE);
+
+        double averageFirstEvalWorkingSetMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevFirstEvalWorkingSetMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double minFirstEvalWorkingSetMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double maxFirstEvalWorkingSetMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+
+        double averageLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double stdevLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetStdev(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double minLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double maxLoadDedicatedMemoryUsage = profiler[LOAD_MODEL].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
+
+        double averageCreateSessionDedicatedMemoryUsage =
             profiler[CREATE_SESSION].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
-
-        double averageBindMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::WORKING_SET_USAGE);
-        double stdevBindMemoryUsage = profiler[BIND_VALUE].GetStdev(CounterType::WORKING_SET_USAGE);
-        double minBindMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::WORKING_SET_USAGE);
-        double maxBindMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::WORKING_SET_USAGE);
-        double firstBindMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
-
-        double averageEvalMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::WORKING_SET_USAGE);
-        double stdevEvalMemoryUsage = profiler[EVAL_MODEL].GetStdev(CounterType::WORKING_SET_USAGE);
-        double minEvalMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::WORKING_SET_USAGE);
-        double maxEvalMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::WORKING_SET_USAGE);
-        double firstEvalMemoryUsage = profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::WORKING_SET_USAGE);
+        double stdevCreateSessionDedicatedMemoryUsage =
+            profiler[CREATE_SESSION].GetStdev(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double minCreateSessionDedicatedMemoryUsage =
+            profiler[CREATE_SESSION].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double maxCreateSessionDedicatedMemoryUsage =
+            profiler[CREATE_SESSION].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double stdevBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetStdev(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxBindDedicatedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstBindDedicatedMemoryUsage =
+
+        double averageFirstBindDedicatedMemoryUsage =
             profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double stdevFirstBindDedicatedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetStdev(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double minFirstBindDedicatedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double maxFirstBindDedicatedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
 
         double averageEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
         double stdevEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetStdev(CounterType::GPU_DEDICATED_MEM_USAGE);
         double minEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_DEDICATED_MEM_USAGE);
         double maxEvalDedicatedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_DEDICATED_MEM_USAGE);
-        double firstEvalDedicatedMemoryUsage =
+
+        double averageFirstEvalDedicatedMemoryUsage =
             profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double stdevFirstEvalDedicatedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double minFirstEvalDedicatedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+        double maxFirstEvalDedicatedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_DEDICATED_MEM_USAGE);
+
+        double averageLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double stdevLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetStdev(CounterType::GPU_SHARED_MEM_USAGE);
+        double minLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
+        double maxLoadSharedMemoryUsage = profiler[LOAD_MODEL].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
+
+        double averageCreateSessionSharedMemoryUsage =
+            profiler[CREATE_SESSION].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double stdevCreateSessionSharedMemoryUsage =
+            profiler[CREATE_SESSION].GetStdev(CounterType::GPU_SHARED_MEM_USAGE);
+        double minCreateSessionSharedMemoryUsage = profiler[CREATE_SESSION].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
+        double maxCreateSessionSharedMemoryUsage = profiler[CREATE_SESSION].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
 
         double averageBindSharedMemoryUsage = profiler[BIND_VALUE].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double stdevBindSharedMemoryUsage = profiler[BIND_VALUE].GetStdev(CounterType::GPU_SHARED_MEM_USAGE);
         double minBindSharedMemoryUsage = profiler[BIND_VALUE].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxBindSharedMemoryUsage = profiler[BIND_VALUE].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstBindSharedMemoryUsage =
+
+        double averageFirstBindSharedMemoryUsage =
             profiler[BIND_VALUE_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double stdevFirstBindSharedMemoryUsage =
+            profiler[BIND_VALUE_FIRST_RUN].GetStdev(CounterType::GPU_SHARED_MEM_USAGE);
+        double minFirstBindSharedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
+        double maxFirstBindSharedMemoryUsage = profiler[BIND_VALUE_FIRST_RUN].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
 
         double averageEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
         double stdevEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetStdev(CounterType::GPU_SHARED_MEM_USAGE);
         double minEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMin(CounterType::GPU_SHARED_MEM_USAGE);
         double maxEvalSharedMemoryUsage = profiler[EVAL_MODEL].GetMax(CounterType::GPU_SHARED_MEM_USAGE);
-        double firstEvalSharedMemoryUsage =
+
+        double averageFirstEvalSharedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double stdevFirstEvalSharedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double minFirstEvalSharedMemoryUsage =
+            profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
+        double maxFirstEvalSharedMemoryUsage =
             profiler[EVAL_MODEL_FIRST_RUN].GetAverage(CounterType::GPU_SHARED_MEM_USAGE);
 
         if (!m_csvFileName.empty())
@@ -868,11 +954,33 @@ public:
                      << ","
                      << "iterations"
                      << ","
-                     << "load (ms)"
+                     << "load iterations"
                      << ","
-                     << "session creation (ms)"
+                     << "session creation iterations"
                      << ","
-                     << "first bind (ms)"
+                     << "average load (ms)"
+                     << ","
+                     << "standard deviation load (ms)"
+                     << ","
+                     << "min load (ms)"
+                     << ","
+                     << "max load (ms)"
+                     << ","
+                     << "average session creation (ms)"
+                     << ","
+                     << "standard deviation session creation (ms)"
+                     << ","
+                     << "min session creation (ms)"
+                     << ","
+                     << "max session creation (ms)"
+                     << ","
+                     << "average first bind (ms)"
+                     << ","
+                     << "standard deviation first bind (ms)"
+                     << ","
+                     << "min first bind (ms)"
+                     << ","
+                     << "max first bind (ms)"
                      << ","
                      << "average bind (ms)"
                      << ","
@@ -882,7 +990,13 @@ public:
                      << ","
                      << "max bind (ms)"
                      << ","
-                     << "first evaluate (ms)"
+                     << "average first evaluate (ms)"
+                     << ","
+                     << "standard deviation first evaluate (ms)"
+                     << ","
+                     << "min first evaluate (ms)"
+                     << ","
+                     << "max first evaluate (ms)"
                      << ","
                      << "average evaluate (ms)"
                      << ","
@@ -892,115 +1006,201 @@ public:
                      << ","
                      << "max evaluate (ms)"
                      << ","
-                     << "load working set memory (MB)"
+                     << "load average working set memory (MB)"
                      << ","
-                     << "session creation working set memory (MB)"
+                     << "load standard deviation working set memory (MB)"
                      << ","
-                     << "first bind working set memory (MB)"
+                     << "load min working set memory (MB)"
+                     << ","
+                     << "load max working set memory (MB)"
+                     << ","
+                     << "session creation average working set memory (MB)"
+                     << ","
+                     << "session creation standard deviation working set memory (MB)"
+                     << ","
+                     << "session creation min working set memory (MB)"
+                     << ","
+                     << "session creation max working set memory (MB)"
+                     << ","
+                     << "first bind average working set memory (MB)"
+                     << ","
+                     << "first bind standard deviation working set memory (MB)"
+                     << ","
+                     << "first bind min working set memory (MB)"
+                     << ","
+                     << "first bind max working set memory (MB)"
                      << ","
                      << "bind average working set memory (MB)"
                      << ","
                      << "bind standard deviation working set memory (MB)"
                      << ","
-                     << "bind max working set memory (MB)"
-                     << ","
                      << "bind min working set memory (MB)"
                      << ","
-                     << "first evaluate working set memory (MB)"
+                     << "bind max working set memory (MB)"
+                     << ","
+                     << "first evaluate average working set memory (MB)"
+                     << ","
+                     << "first evaluate standard deviation working set memory (MB)"
+                     << ","
+                     << "first evaluate min working set memory (MB)"
+                     << ","
+                     << "first evaluate max working set memory (MB)"
                      << ","
                      << "evaluate average working set memory (MB)"
                      << ","
                      << "evaluate standard deviation working set memory (MB)"
                      << ","
-                     << "evaluate max working set memory (MB)"
-                     << ","
                      << "evaluate min working set memory (MB)"
                      << ","
-                     << "load dedicated memory (MB)"
+                     << "evaluate max working set memory (MB)"
                      << ","
-                     << "session creation dedicated memory (MB)"
+                     << "load average dedicated memory (MB)"
                      << ","
-                     << "first bind dedicated memory (MB)"
+                     << "load standard deviation dedicated memory (MB)"
+                     << ","
+                     << "load min dedicated memory (MB)"
+                     << ","
+                     << "load max dedicated memory (MB)"
+                     << ","
+                     << "session creation average dedicated memory (MB)"
+                     << ","
+                     << "session creation standard deviation dedicated memory (MB)"
+                     << ","
+                     << "session creation min dedicated memory (MB)"
+                     << ","
+                     << "session creation max dedicated memory (MB)"
+                     << ","
+                     << "first bind average dedicated memory (MB)"
+                     << ","
+                     << "first bind standard deviation dedicated memory (MB)"
+                     << ","
+                     << "first bind min dedicated memory (MB)"
+                     << ","
+                     << "first bind max dedicated memory (MB)"
                      << ","
                      << "bind average dedicated memory (MB)"
                      << ","
                      << "bind standard deviation dedicated memory (MB)"
                      << ","
-                     << "bind max dedicated memory (MB)"
-                     << ","
                      << "bind min dedicated memory (MB)"
                      << ","
-                     << "first evaluate dedicated memory (MB)"
+                     << "bind max dedicated memory (MB)"
+                     << ","
+                     << "first evaluate average dedicated memory (MB)"
+                     << ","
+                     << "first evaluate standard deviation dedicated memory (MB)"
+                     << ","
+                     << "first evaluate min dedicated memory (MB)"
+                     << ","
+                     << "first evaluate max dedicated memory (MB)"
                      << ","
                      << "evaluate average dedicated memory (MB)"
                      << ","
                      << "evaluate standard deviation dedicated memory (MB)"
                      << ","
-                     << "evaluate max dedicated memory (MB)"
-                     << ","
                      << "evaluate min dedicated memory (MB)"
                      << ","
-                     << "load shared memory (MB)"
+                     << "evaluate max dedicated memory (MB)"
                      << ","
-                     << "session creation shared memory (MB)"
+                     << "load average shared memory (MB)"
                      << ","
-                     << "first bind shared memory (MB)"
+                     << "load standard deviation shared memory (MB)"
+                     << ","
+                     << "load min shared memory (MB)"
+                     << ","
+                     << "load max shared memory (MB)"
+                     << ","
+                     << "session creation average shared memory (MB)"
+                     << ","
+                     << "session creation standard deviation shared memory (MB)"
+                     << ","
+                     << "session creation min shared memory (MB)"
+                     << ","
+                     << "session creation max shared memory (MB)"
+                     << ","
+                     << "first bind average shared memory (MB)"
+                     << ","
+                     << "first bind standard deviation shared memory (MB)"
+                     << ","
+                     << "first bind min shared memory (MB)"
+                     << ","
+                     << "first bind max shared memory (MB)"
                      << ","
                      << "bind average shared memory (MB)"
                      << ","
                      << "bind standard deviation shared memory (MB)"
                      << ","
-                     << "bind max shared memory (MB)"
-                     << ","
                      << "bind min shared memory (MB)"
                      << ","
-                     << "first evaluate shared memory (MB)"
+                     << "bind max shared memory (MB)"
+                     << ","
+                     << "first evaluate average shared memory (MB)"
+                     << ","
+                     << "first evaluate standard deviation shared memory (MB)"
+                     << ","
+                     << "first evaluate min shared memory (MB)"
+                     << ","
+                     << "first evaluate max shared memory (MB)"
                      << ","
                      << "evaluate average shared memory (MB)"
                      << ","
                      << "evaluate standard deviation shared memory (MB)"
                      << ","
-                     << "evaluate max shared memory (MB)"
-                     << ","
                      << "evaluate min shared memory (MB)"
+                     << ","
+                     << "evaluate max shared memory (MB)"
                      << ",";
                 for (auto metaDataPair : perfFileMetadata)
                 {
                     fout << metaDataPair.first << ",";
                 }
-                    fout << std::endl;
+                fout << std::endl;
             }
             fout << modelName << "," << deviceType << "," << inputBinding << "," << inputType << ","
-                 << deviceCreationLocation << "," << numIterations << "," << loadTime << "," << createSessionTime << ","
-                 << firstBindTime << "," << (numIterations <= 1 ? 0 : averageBindTime) << ","
-                 << (numIterations <= 1 ? 0 : stdevBindTime) << ","
+                 << deviceCreationLocation << "," << numIterations << "," << numberLoadIterations << "," << numberCreateSessionIterations << "," 
+                 << averageLoadTime << "," << stdevLoadTime << "," << minLoadTime << "," << maxLoadTime << ","
+                 << averageCreateSessionTime << "," << stdevCreateSessionTime << "," << minCreateSessionTime << "," << maxCreateSessionTime << ","
+                 << averageFirstBindTime << "," << stdevFirstBindTime << "," << minFirstBindTime << "," << maxFirstBindTime << ","
+                 << (numIterations <= 1 ? 0 : averageBindTime) << "," << (numIterations <= 1 ? 0 : stdevBindTime) << ","
                  << (numIterations <= 1 ? 0 : minBindTime) << "," << (numIterations <= 1 ? 0 : maxBindTime) << ","
-                 << firstEvalTime << "," << (numIterations <= 1 ? 0 : averageEvalTime) << "," 
-                 << (numIterations <= 1 ? 0 : stdevEvalTime) << ","
+                 << averageFirstEvalTime << "," << stdevFirstEvalTime << "," << minFirstEvalTime << "," << maxFirstEvalTime<< ","
+                 << (numIterations <= 1 ? 0 : averageEvalTime) << "," << (numIterations <= 1 ? 0 : stdevEvalTime) << "," 
                  << (numIterations <= 1 ? 0 : minEvalTime) << "," << (numIterations <= 1 ? 0 : maxEvalTime) << ","
-                 << firstLoadWorkingSetMemoryUsage << "," << firstSessionCreationWorkingSetMemoryUsage << ","
-                 << firstBindMemoryUsage << "," << (numIterations <= 1 ? 0 : averageBindMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : stdevBindMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : maxBindMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : minBindMemoryUsage) << "," << firstEvalMemoryUsage << ","
-                 << (numIterations <= 1 ? 0 : averageEvalMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : stdevEvalMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : maxEvalMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : minEvalMemoryUsage) << "," << firstLoadDedicatedMemoryUsage << ","
-                 << firstSessionCreationDedicatedMemoryUsage << "," << firstBindDedicatedMemoryUsage << ","
+                 
+                 << averageLoadWorkingSetMemoryUsage << "," << stdevLoadWorkingSetMemoryUsage << "," << minLoadWorkingSetMemoryUsage << "," << maxLoadWorkingSetMemoryUsage << ","
+                 << averageCreateSessionWorkingSetMemoryUsage << "," << stdevCreateSessionWorkingSetMemoryUsage << "," << minCreateSessionWorkingSetMemoryUsage << "," << maxCreateSessionWorkingSetMemoryUsage << ","
+                 << averageFirstBindWorkingSetMemoryUsage << "," << stdevFirstBindWorkingSetMemoryUsage << "," << minFirstBindWorkingSetMemoryUsage << "," << maxFirstBindWorkingSetMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageBindWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : stdevBindWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxBindWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minBindWorkingSetMemoryUsage) << ","
+                 << averageFirstBindWorkingSetMemoryUsage << "," << stdevFirstBindWorkingSetMemoryUsage << "," << minFirstBindWorkingSetMemoryUsage << "," << maxFirstBindWorkingSetMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : averageEvalWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : stdevEvalWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : maxEvalWorkingSetMemoryUsage) << ","
+                 << (numIterations <= 1 ? 0 : minEvalWorkingSetMemoryUsage) << ","
+                 
+                 << averageLoadDedicatedMemoryUsage << "," << stdevLoadDedicatedMemoryUsage << "," << minLoadDedicatedMemoryUsage << "," << maxLoadDedicatedMemoryUsage << ","
+                 << averageCreateSessionDedicatedMemoryUsage << "," << stdevCreateSessionDedicatedMemoryUsage << "," << minCreateSessionDedicatedMemoryUsage << "," << maxCreateSessionDedicatedMemoryUsage << ","
+                 << averageFirstBindDedicatedMemoryUsage << "," << stdevFirstBindDedicatedMemoryUsage << "," << minFirstBindDedicatedMemoryUsage << "," << maxFirstBindDedicatedMemoryUsage << ","
                  << (numIterations <= 1 ? 0 : averageBindDedicatedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : stdevBindDedicatedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : maxBindDedicatedMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : minBindDedicatedMemoryUsage) << "," << firstEvalDedicatedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : minBindDedicatedMemoryUsage) << ","
+                 << averageFirstBindDedicatedMemoryUsage << "," << stdevFirstBindDedicatedMemoryUsage << "," << minFirstBindDedicatedMemoryUsage << "," << maxFirstBindDedicatedMemoryUsage << ","
                  << (numIterations <= 1 ? 0 : averageEvalDedicatedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : stdevEvalDedicatedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : maxEvalDedicatedMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : minEvalDedicatedMemoryUsage) << "," << firstLoadSharedMemoryUsage << ","
-                 << firstSessionCreationSharedMemoryUsage << "," << firstBindSharedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : minEvalDedicatedMemoryUsage) << ","
+
+                 << averageLoadSharedMemoryUsage << "," << stdevLoadSharedMemoryUsage << "," << minLoadSharedMemoryUsage << "," << maxLoadSharedMemoryUsage << ","
+                 << averageCreateSessionSharedMemoryUsage << "," << stdevCreateSessionSharedMemoryUsage << "," << minCreateSessionSharedMemoryUsage << "," << maxCreateSessionSharedMemoryUsage << ","
+                 << averageFirstBindSharedMemoryUsage << "," << stdevFirstBindSharedMemoryUsage << "," << minFirstBindSharedMemoryUsage << "," << maxFirstBindSharedMemoryUsage << ","
                  << (numIterations <= 1 ? 0 : averageBindSharedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : stdevBindSharedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : maxBindSharedMemoryUsage) << ","
-                 << (numIterations <= 1 ? 0 : minBindSharedMemoryUsage) << "," << firstEvalSharedMemoryUsage << ","
+                 << (numIterations <= 1 ? 0 : minBindSharedMemoryUsage) << ","
+                 << averageFirstBindSharedMemoryUsage << "," << stdevFirstBindSharedMemoryUsage << "," << minFirstBindSharedMemoryUsage << "," << maxFirstBindSharedMemoryUsage << ","
                  << (numIterations <= 1 ? 0 : averageEvalSharedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : stdevEvalSharedMemoryUsage) << ","
                  << (numIterations <= 1 ? 0 : maxEvalSharedMemoryUsage) << ","

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -89,18 +89,21 @@ HRESULT LoadModel(LearningModel& model, const std::wstring& path, bool capturePe
     try
     {
         output.PrintLoadingInfo(path);
-        if (capturePerf)
+        for (uint32_t loadIteration = 0; loadIteration < args.NumLoadIterations(); loadIteration++)
         {
-            WINML_PROFILING_START(profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
-        }
-        model = LearningModel::LoadFromFilePath(path);
-
-        if (capturePerf)
-        {
-            WINML_PROFILING_STOP(profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
-            if (args.IsPerIterationCapture())
+            if (capturePerf)
             {
-                output.SaveLoadTimes(profiler, iterationNum);
+                WINML_PROFILING_START(profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
+            }
+            model = LearningModel::LoadFromFilePath(path);
+
+            if (capturePerf)
+            {
+                WINML_PROFILING_STOP(profiler, WINML_MODEL_TEST_PERF::LOAD_MODEL);
+                if (args.IsPerIterationCapture())
+                {
+                    output.SaveLoadTimes(profiler, iterationNum);
+                }
             }
         }
         output.PrintModelInfo(path, model);
@@ -648,33 +651,33 @@ void PrintIfPIXToolAttached(OutputHelper& output)
 }
 #endif
 
-void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModelSession& session, HRESULT& lastHr,
-                      LearningModel& model, const DeviceType deviceType, const InputBindingType inputBindingType,
-                      const InputDataType inputDataType, const IDirect3DDevice& winrtDevice,
-                      const DeviceCreationLocation deviceCreationLocation, Profiler<WINML_MODEL_TEST_PERF>& profiler,
-                      const std::wstring& modelPath, const std::wstring& imagePath)
+void IterateBindAndEvaluate(const int maxBindAndEvalIterations, int& lastIteration, CommandLineArgs& args, OutputHelper& output,
+                            LearningModelSession& session, HRESULT& lastHr, LearningModel& model,
+                            const DeviceType deviceType, const InputBindingType inputBindingType,
+                            const InputDataType inputDataType, const IDirect3DDevice& winrtDevice,
+                            const DeviceCreationLocation deviceCreationLocation,
+                            Profiler<WINML_MODEL_TEST_PERF>& profiler, const std::wstring& imagePath)
 {
     Timer iterationTimer;
-    uint32_t iterationNum = 0;
-    for (; iterationNum < args.NumIterations(); iterationNum++)
+    for (; lastIteration < maxBindAndEvalIterations; lastIteration++)
     {
 #if defined(_AMD64_)
         // PIX markers only work on AMD64
         // If PIX tool was attached then capture already began for the first iteration before
         // session creation. This is to begin PIX capture for each iteration after the first
         // iteration.
-        if (iterationNum > 0)
+        if (lastIteration > 0)
         {
             StartPIXCapture(output);
         }
 #endif
         if (args.IsTimeLimitIterations())
         {
-            if (iterationNum == 1)
+            if (lastIteration == 1)
             {
                 iterationTimer.Start();
             }
-            else if (iterationNum >= 1 && iterationTimer.Stop() >= args.IterationTimeLimit())
+            else if (lastIteration >= 1 && iterationTimer.Stop() >= args.IterationTimeLimit())
             {
                 std::cout << "Iteration time exceeded limit specified. Exiting.." << std::endl;
                 break;
@@ -682,31 +685,29 @@ void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModel
         }
         LearningModelBinding context(session);
         lastHr = BindInputs(context, model, session, output, deviceType, args, inputBindingType, inputDataType,
-                            winrtDevice, deviceCreationLocation, iterationNum, profiler, imagePath);
+                            winrtDevice, deviceCreationLocation, lastIteration, profiler, imagePath);
         if (FAILED(lastHr))
         {
             break;
         }
         LearningModelEvaluationResult result = nullptr;
         bool capture_perf = args.IsPerformanceCapture() || args.IsPerIterationCapture();
-        lastHr = EvaluateModel(result, model, context, session, args, output, capture_perf, iterationNum, profiler);
+        lastHr = EvaluateModel(result, model, context, session, args, output, capture_perf, lastIteration, profiler);
         if (FAILED(lastHr))
         {
-            output.PrintEvaluatingInfo(iterationNum + 1, deviceType, inputBindingType, inputDataType,
-                                       deviceCreationLocation,
-                                       "[FAILED]");
+            output.PrintEvaluatingInfo(lastIteration + 1, deviceType, inputBindingType, inputDataType,
+                                       deviceCreationLocation, "[FAILED]");
             break;
         }
-        else if (!args.TerseOutput() || iterationNum == 0)
+        else if (!args.TerseOutput() || lastIteration == 0)
         {
-            output.PrintEvaluatingInfo(iterationNum + 1, deviceType, inputBindingType, inputDataType,
-                                       deviceCreationLocation,
-                                       "[SUCCESS]");
+            output.PrintEvaluatingInfo(lastIteration + 1, deviceType, inputBindingType, inputDataType,
+                                       deviceCreationLocation, "[SUCCESS]");
 
             // Only print eval results on the first iteration, iff it's not garbage data
             if (!args.IsGarbageInput() || args.IsSaveTensor())
             {
-                BindingUtilities::PrintOrSaveEvaluationResults(model, args, result.Outputs(), output, iterationNum);
+                BindingUtilities::PrintOrSaveEvaluationResults(model, args, result.Outputs(), output, lastIteration);
             }
 
             if (args.TerseOutput() && args.NumIterations() > 1)
@@ -719,27 +720,58 @@ void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModel
         EndPIXCapture(output);
 #endif
     }
+}
 
-    // print metrics after iterations
-    if (SUCCEEDED(lastHr) && args.IsPerformanceCapture())
+void RunBindAndEvaluateOnce(CommandLineArgs& args, OutputHelper& output, LearningModelSession& session,
+                            HRESULT& lastHr, LearningModel& model, const DeviceType deviceType,
+                            const InputBindingType inputBindingType, const InputDataType inputDataType, 
+                            const IDirect3DDevice& winrtDevice, const DeviceCreationLocation deviceCreationLocation,
+                            Profiler<WINML_MODEL_TEST_PERF>& profiler, const std::wstring& imagePath)
+{
+    int lastIteration = 0;
+    IterateBindAndEvaluate(1, lastIteration, args, output, session, lastHr, model, deviceType,
+                           inputBindingType, inputDataType, winrtDevice, deviceCreationLocation, profiler, imagePath);
+}
+
+void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModelSession& session, HRESULT& lastHr,
+                      LearningModel& model, const DeviceType deviceType, const InputBindingType inputBindingType,
+                      const InputDataType inputDataType, const IDirect3DDevice& winrtDevice,
+                      const DeviceCreationLocation deviceCreationLocation, Profiler<WINML_MODEL_TEST_PERF>& profiler,
+                      const std::wstring& modelPath, const std::wstring& imagePath,
+                      const uint32_t sessionCreationIteration)
+{
+    if (sessionCreationIteration < args.NumSessionCreationIterations() - 1)
     {
-        output.PrintResults(profiler, iterationNum, deviceType, inputBindingType, inputDataType,
-                            deviceCreationLocation, args.IsPerformanceConsoleOutputVerbose());
-        if (args.IsOutputPerf())
-        {
-            std::string deviceTypeStringified = TypeHelper::Stringify(deviceType);
-            std::string inputDataTypeStringified = TypeHelper::Stringify(inputDataType);
-            std::string inputBindingTypeStringified = TypeHelper::Stringify(inputBindingType);
-            std::string deviceCreationLocationStringified = TypeHelper::Stringify(deviceCreationLocation);
-            output.WritePerformanceDataToCSV(profiler, iterationNum, modelPath, deviceTypeStringified,
-                                                inputDataTypeStringified, inputBindingTypeStringified,
-                                                deviceCreationLocationStringified, args.GetPerformanceFileMetadata());
-        }
+        RunBindAndEvaluateOnce(args, output, session, lastHr, model, deviceType, inputBindingType,
+                               inputDataType, winrtDevice, deviceCreationLocation, profiler, imagePath);
+        return;
     }
-
-    if (SUCCEEDED(lastHr) && args.IsPerIterationCapture())
+    else
     {
-        output.WritePerIterationPerformance(args, model.Name().c_str(), imagePath);
+        int lastIteration = 0;
+        IterateBindAndEvaluate(args.NumIterations(), lastIteration, args, output, session, lastHr, model, deviceType,
+                               inputBindingType, inputDataType, winrtDevice, deviceCreationLocation, profiler, imagePath);
+        // print metrics after iterations
+        if (SUCCEEDED(lastHr) && args.IsPerformanceCapture())
+        {
+            output.PrintResults(profiler, lastIteration, deviceType, inputBindingType, inputDataType,
+                                deviceCreationLocation, args.IsPerformanceConsoleOutputVerbose());
+            if (args.IsOutputPerf())
+            {
+                std::string deviceTypeStringified = TypeHelper::Stringify(deviceType);
+                std::string inputDataTypeStringified = TypeHelper::Stringify(inputDataType);
+                std::string inputBindingTypeStringified = TypeHelper::Stringify(inputBindingType);
+                std::string deviceCreationLocationStringified = TypeHelper::Stringify(deviceCreationLocation);
+                output.WritePerformanceDataToCSV(profiler, lastIteration, modelPath, deviceTypeStringified,
+                                                 inputDataTypeStringified, inputBindingTypeStringified,
+                                                 deviceCreationLocationStringified, args.GetPerformanceFileMetadata());
+            }
+        }
+
+        if (SUCCEEDED(lastHr) && args.IsPerIterationCapture())
+        {
+            output.WritePerIterationPerformance(args, model.Name().c_str(), imagePath);
+        }
     }
 }
 int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
@@ -799,39 +831,45 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
 #endif
                     LearningModelSession session = nullptr;
                     IDirect3DDevice winrtDevice = nullptr;
-                    lastHr = CreateSession(session, winrtDevice, model, args, output, deviceType,
-                                           deviceCreationLocation, profiler);
-                    if (FAILED(lastHr))
-                    {
-                        continue;
-                    }
                     for (auto inputDataType : inputDataTypes)
                     {
                         for (auto inputBindingType : inputBindingTypes)
                         {
-                            // Clear up bind, eval performance metrics after iteration
+                            // Clear up session, bind, eval performance metrics after configuration iteration
                             if (args.IsPerformanceCapture() || args.IsPerIterationCapture())
                             {
                                 // Resets all values from profiler for bind and evaluate.
                                 profiler.Reset(WINML_MODEL_TEST_PERF::BIND_VALUE, WINML_MODEL_TEST_PERF::COUNT);
                             }
-                            if (args.IsImageInput())
+                            for (uint32_t sessionCreationIteration = 0;
+                                sessionCreationIteration < args.NumSessionCreationIterations();
+                                sessionCreationIteration++)
                             {
-                                for (const std::wstring& inputImagePath : args.ImagePaths())
+                                lastHr = CreateSession(session, winrtDevice, model, args, output, deviceType,
+                                                       deviceCreationLocation, profiler);
+                                if (FAILED(lastHr))
                                 {
+                                    continue;
+                                }
+                                if (args.IsImageInput())
+                                {
+                                    for (const std::wstring& inputImagePath : args.ImagePaths())
+                                    {
+                                        RunConfiguration(args, output, session, lastHr, model, deviceType,
+                                                         inputBindingType, inputDataType, winrtDevice,
+                                                         deviceCreationLocation, profiler, path, inputImagePath,
+                                                         sessionCreationIteration);
+                                    }
+                                }
+                                else
+                                {
+                                    const std::wstring& inputImagePath = L"";
                                     RunConfiguration(args, output, session, lastHr, model, deviceType, inputBindingType,
                                                      inputDataType, winrtDevice, deviceCreationLocation, profiler, path,
-                                                     inputImagePath);
+                                                     L"", sessionCreationIteration);
                                 }
                             }
-                            else
-                            {
-                                const std::wstring& inputImagePath = L"";
-                                RunConfiguration(args, output, session, lastHr, model, deviceType, inputBindingType,
-                                                 inputDataType, winrtDevice, deviceCreationLocation, profiler, path,
-                                                 L"");
-                            }
-                       }
+                        }
                     }
                 }
             }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -868,6 +868,9 @@ int run(CommandLineArgs& args, Profiler<WINML_MODEL_TEST_PERF>& profiler) try
                                                      inputDataType, winrtDevice, deviceCreationLocation, profiler, path,
                                                      L"", sessionCreationIteration);
                                 }
+                                // Close and destroy session
+                                session.Close();
+                                session.~LearningModelSession();
                             }
                         }
                     }


### PR DESCRIPTION
This change allows multiple iterations for loading a model and also multiple iterations for session creation  for WinMLRunner static library.

The purpose of this change is for performance measuring, it is better to run load / session creation / first bind / first eval multiple times to get stability.

**NOTE:** This PR changes the schema of the performance file.