### PR TITLE
allow specifying an adapter name also when using old DXGI

### DIFF
--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -21,10 +21,7 @@ void CommandLineArgs::PrintUsage()
     std::cout << "  -GPU : run model on default GPU" << std::endl;
     std::cout << "  -GPUHighPerformance : run model on GPU with highest performance" << std::endl;
     std::cout << "  -GPUMinPower : run model on GPU with the least power" << std::endl;
-#ifdef DXCORE_SUPPORTED_BUILD
-    std::cout << "  -GPUAdapterName <adapter name substring>: run model on GPU specified by its name. NOTE: Please only use this flag on DXCore supported machines." 
-              << std::endl;
-#endif
+    std::cout << "  -GPUAdapterName <adapter name substring>: run model on GPU specified by its name."  << std::endl;
     std::cout << "  -CreateDeviceOnClient : create the D3D device on the client and pass it to WinML to create session" << std::endl;
     std::cout << "  -CreateDeviceInWinML : create the device inside WinML" << std::endl;
     std::cout << "  -CPUBoundInput : bind the input to the CPU" << std::endl;
@@ -101,22 +98,23 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
         {
             m_useGPUMinPower = true;
         }
-#ifdef DXCORE_SUPPORTED_BUILD
+
         else if ((_wcsicmp(args[i].c_str(), L"-GPUAdapterName") == 0) || (_wcsicmp(args[i].c_str(), L"-GPUAdapterIndex") == 0))
         {
             CheckNextArgument(args, i);
-            HMODULE library = nullptr;
+#ifdef DXCORE_SUPPORTED_BUILD
+			HMODULE library = nullptr;
             library = LoadLibrary(L"dxcore.dll");
             if (!library)
             {
                 throw hresult_invalid_argument(
                     L"ERROR: DXCORE isn't supported on this machine. "
                     L"GpuAdapterName flag should only be used with DXCore supported machines.");
-                }
+             }
+#endif
             m_adapterName = args[++i];
             m_useGPU = true;
         }
-#endif
         else if ((_wcsicmp(args[i].c_str(), L"-CreateDeviceOnClient") == 0))
         {
             m_createDeviceOnClient = true;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -31,9 +31,8 @@ public:
     const std::wstring& ModelPath() const { return m_modelPath; }
     const std::wstring& PerIterationDataPath() const { return m_perIterationDataPath; }
     std::vector<std::pair<std::string, std::string>>& GetPerformanceFileMetadata() { return m_perfFileMetadata; }
-#ifdef DXCORE_SUPPORTED_BUILD
     const std::wstring& GetGPUAdapterName() const { return m_adapterName; }
-#endif
+
 
     bool UseRGB() const
     {
@@ -155,9 +154,7 @@ private:
     std::wstring m_inputImageFolderPath;
     std::wstring m_csvData;
     std::wstring m_inputData;
-#ifdef DXCORE_SUPPORTED_BUILD
     std::wstring m_adapterName;
-#endif
     std::wstring m_perfOutputPath;
     std::wstring m_perIterationDataPath;
     uint32_t m_numIterations = 1;

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -141,9 +141,9 @@ HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevic
     {
         return hresult_invalid_argument().code();
     }
-#ifdef DXCORE_SUPPORTED_BUILD
+
     const std::wstring& adapterName = args.GetGPUAdapterName();
-#endif
+
     try
     {
         if (deviceCreationLocation == DeviceCreationLocation::UserD3DDevice && deviceType != DeviceType::CPU)
@@ -157,8 +157,29 @@ HRESULT CreateSession(LearningModelSession& session, IDirect3DDevice& winrtDevic
             switch (deviceType)
             {
                 case DeviceType::DefaultGPU:
-                    hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_UNSPECIFIED, __uuidof(IDXGIAdapter),
-                                                             adapter.put_void());
+					if (adapterName.empty())
+					{
+						hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                                                                 __uuidof(IDXGIAdapter), adapter.put_void());
+					}
+					else
+					{
+						DXGI_ADAPTER_DESC desc;
+						
+						int adapterIndex = 0;
+						do
+                        {
+                            hr = factory->EnumAdapters(adapterIndex, adapter.put());
+
+							if (adapter)
+							{
+								adapter->GetDesc(&desc);
+							}
+
+							adapterIndex++;
+                        } while ((hr != DXGI_ERROR_NOT_FOUND) &&
+                                 (wcsstr(desc.Description, adapterName.c_str()) == NULL));
+					}
                     break;
                 case DeviceType::MinPowerGPU:
                     hr = factory->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_MINIMUM_POWER,


### PR DESCRIPTION
I see no need to use DXCORE to specify an adapter name.