### PR TITLE
Remove WINRT_CoIncrementMTAUsage redefinition

### DIFF
--- a/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
+++ b/Samples/SqueezeNetObjectDetection/Desktop/cpp/main.cpp
@@ -199,8 +199,3 @@ void PrintResults(IVectorView<float> results)
         printf("%s with confidence of %f\n", labels[curr.second].c_str(), curr.first);
     }
 }
-
-int32_t WINRT_CALL WINRT_CoIncrementMTAUsage(void** cookie) noexcept
-{
-    return CoIncrementMTAUsage((CO_MTA_USAGE_COOKIE*)cookie);
-}


### PR DESCRIPTION
WINRT_CoIncrementMTAUsage definition was required for C++/WinRT prior to RS5 SDK. 
Verified that this change works on RS5 and 19H1 SDK (17763 and 18362)