### PR TITLE
Can't use DXGI to print adapter name of VPU

### DIFF
--- a/Tools/WinMLRunner/src/LearningModelDeviceHelper.cpp
+++ b/Tools/WinMLRunner/src/LearningModelDeviceHelper.cpp
@@ -220,9 +220,12 @@ void PopulateLearningModelDeviceList(CommandLineArgs& args, std::vector<Learning
 #endif
                 else
                 {
-                    LearningModelDeviceWithMetadata learningModelDeviceWithMetadata = { LearningModelDevice(
-                                                                 TypeHelper::GetWinmlDeviceKind(deviceType)),
-                                                             deviceType, deviceCreationLocation };
+                    LearningModelDeviceWithMetadata learningModelDeviceWithMetadata = 
+                    { 
+                        LearningModelDevice( TypeHelper::GetWinmlDeviceKind(deviceType)),
+                                             deviceType, 
+                                             deviceCreationLocation 
+                    };
                     OutputHelper::PrintLearningModelDevice(learningModelDeviceWithMetadata);
                     deviceList.push_back(learningModelDeviceWithMetadata);
                 }

--- a/Tools/WinMLRunner/src/LearningModelDeviceHelper.cpp
+++ b/Tools/WinMLRunner/src/LearningModelDeviceHelper.cpp
@@ -6,6 +6,7 @@
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
 #include "Windows.AI.MachineLearning.Native.h"
 #include <codecvt>
+#include "OutputHelper.h"
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
 #ifdef DXCORE_SUPPORTED_BUILD
@@ -83,11 +84,14 @@ void PopulateLearningModelDeviceList(CommandLineArgs& args, std::vector<Learning
                     com_ptr<IInspectable> inspectableDevice;
                     hr = CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice.get(), inspectableDevice.put());
                     THROW_IF_FAILED(hr);
-                    deviceList.push_back({
+                    LearningModelDeviceWithMetadata learningModelDeviceWithMetadata =
+                        {
                         LearningModelDevice::CreateFromDirect3D11Device(inspectableDevice.as<IDirect3DDevice>()),
                         deviceType,
                         deviceCreationLocation
-                        });
+                        };
+                    OutputHelper::PrintLearningModelDevice(learningModelDeviceWithMetadata);
+                    deviceList.push_back(learningModelDeviceWithMetadata);
                 }
 #ifdef DXCORE_SUPPORTED_BUILD
                 else if ((TypeHelper::GetWinmlDeviceKind(deviceType) != LearningModelDeviceKind::Cpu) &&
@@ -216,11 +220,11 @@ void PopulateLearningModelDeviceList(CommandLineArgs& args, std::vector<Learning
 #endif
                 else
                 {
-                    deviceList.push_back({
-                        LearningModelDevice(TypeHelper::GetWinmlDeviceKind(deviceType)),
-                        deviceType,
-                        deviceCreationLocation
-                        });
+                    LearningModelDeviceWithMetadata learningModelDeviceWithMetadata = { LearningModelDevice(
+                                                                 TypeHelper::GetWinmlDeviceKind(deviceType)),
+                                                             deviceType, deviceCreationLocation };
+                    OutputHelper::PrintLearningModelDevice(learningModelDeviceWithMetadata);
+                    deviceList.push_back(learningModelDeviceWithMetadata);
                 }
             }
             catch (...)

--- a/Tools/WinMLRunner/src/OutputHelper.h
+++ b/Tools/WinMLRunner/src/OutputHelper.h
@@ -165,11 +165,11 @@ public:
         std::cout << std::endl;
     }
 
-    void PrintLearningModelDevice(const LearningModelDeviceWithMetadata& device)
+    static void PrintLearningModelDevice(const LearningModelDeviceWithMetadata& device)
     {
         if (device.DeviceType == DeviceType::CPU)
         {
-            std::cout << "\nCreating Session with CPU device" << std::endl;
+            std::cout << "\nCreated LearningModelDevice with CPU device" << std::endl;
             return;
         }
 
@@ -185,7 +185,7 @@ public:
             DXGI_ADAPTER_DESC description;
             if (SUCCEEDED(adapter->GetDesc(&description)))
             {
-                std::wcout << L"\nCreating Session with GPU: " << description.Description << std::endl;
+                std::wcout << L"\nCreated LearningModelDevice with GPU: " << description.Description << std::endl;
             }
         }
         else

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -180,7 +180,6 @@ HRESULT CreateSession(LearningModelSession& session, LearningModel& model, const
     }
     try
     {
-        output.PrintLearningModelDevice(learningModelDevice);
         CreateSessionConsideringSupportForSessionOptions(session, model, profiler, args, learningModelDevice);
     }
     catch (hresult_error hr)


### PR DESCRIPTION
This is a temporary fix to fix the break to print out adaptername from LearningModelDevice . There is additional work to use LUID to use DxCore to print out adapter name