### PR TITLE
remove WINRT_CoIncrementMTAUsage in AdapterSelection

### DIFF
--- a/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
+++ b/Samples/AdapterSelection/AdapterSelection/cpp/main.cpp
@@ -235,8 +235,3 @@ void PrintResults(IVectorView<float> results)
         printf("%s with confidence of %f\n", labels[curr.second].c_str(), curr.first);
     }
 }
-
-int32_t WINRT_CALL WINRT_CoIncrementMTAUsage(void** cookie) noexcept
-{
-	return CoIncrementMTAUsage((CO_MTA_USAGE_COOKIE*)cookie);
-}


### PR DESCRIPTION
This originally was a workaround for a bug that was fixed in RS5. In line with this PR that removes it from the Squeezenet sample: https://github.com/microsoft/Windows-Machine-Learning/pull/262