### PR TITLE
remove Microsoft Engagement Framework package and all usages

### DIFF
--- a/Samples/Emoji8/UWP/cs/Emoji8/Constants.cs
+++ b/Samples/Emoji8/UWP/cs/Emoji8/Constants.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. 
 // Licensed under the MIT license. 
 
-using Microsoft.Services.Store.Engagement;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -39,7 +38,5 @@ namespace Emoji8
         public static readonly string TwitterConsumerKey = "";
         public static readonly string TwitterConsumerSecret = "";
         public static readonly string TwitterCallbackURI = "";
-
-        public static StoreServicesCustomEventLogger LOGGER = StoreServicesCustomEventLogger.GetDefault();
     }
 }

--- a/Samples/Emoji8/UWP/cs/Emoji8/Emoji8.csproj
+++ b/Samples/Emoji8/UWP/cs/Emoji8/Emoji8.csproj
@@ -208,9 +208,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.7</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Services.Store.Engagement">
-      <Version>10.1711.28001</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Services">
       <Version>4.0.0</Version>
     </PackageReference>
@@ -231,9 +228,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
-      <Name>Microsoft Engagement Framework</Name>
-    </SDKReference>
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>

--- a/Samples/Emoji8/UWP/cs/Emoji8/Pages/MainPage.xaml.cs
+++ b/Samples/Emoji8/UWP/cs/Emoji8/Pages/MainPage.xaml.cs
@@ -71,7 +71,7 @@ namespace Emoji8
                 Debug.WriteLine("Finished cleaning up MainPage, ready to move onto EmotionPage");
             }
 
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerStartButtonClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerStartButtonClicked"));
             Frame.Navigate(typeof(EmotionPage));
         }
 

--- a/Samples/Emoji8/UWP/cs/Emoji8/Pages/ResultsPage.xaml.cs
+++ b/Samples/Emoji8/UWP/cs/Emoji8/Pages/ResultsPage.xaml.cs
@@ -16,6 +16,7 @@ using Emoji8.Services;
 using Emoji8.Pages.PageHelpers;
 using Microsoft.Toolkit.Services.Twitter;
 using System.IO;
+using System.Diagnostics;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -124,7 +125,7 @@ namespace Emoji8
             Gif.Source = null;
             brandedGif.Source = null;
 
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerPlayAgainClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerPlayAgainClicked"));
             Frame.Navigate(typeof(EmotionPage));
         }
 
@@ -133,11 +134,11 @@ namespace Emoji8
             try
             {
                 await EstablishTwitterUserAsync();
-                Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerShareToTwitterClicked"));
+                Debug.WriteLine(GameText.LOADER.GetString("LoggerShareToTwitterClicked"));
             }
             catch (Exception ex)
             {
-                Constants.LOGGER.Log($"{GameText.LOADER.GetString("LoggerShareToTwitterError")} {ex.Message}");
+                Debug.WriteLine($"{GameText.LOADER.GetString("LoggerShareToTwitterError")} {ex.Message}");
                 await MessageDialogService.Current.WriteMessage(GameText.LOADER.GetString("TwitterServiceUnavailable"));
                 await ReturnScreenToNormalAfterPopupAsync(PostTweetBorder);
                 return;
@@ -150,7 +151,7 @@ namespace Emoji8
 
             //confirmed user can now edit Tweet content
             CreateTweet();
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerContinuePostingYesClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerContinuePostingYesClicked"));
         }
 
         private async void ContinueAsLoggedInUserClickedNo(object sender, RoutedEventArgs e)
@@ -160,13 +161,13 @@ namespace Emoji8
             //log out user and prompt then to log in again
             TwitterService.Instance.Logout();
             await EstablishTwitterUserAsync();
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerContinuePostingNoClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerContinuePostingNoClicked"));
         }
 
         private async void PostTweetClickedCancel(object sender, RoutedEventArgs e)
         {
             await ReturnScreenToNormalAfterPopupAsync(PostTweetBorder);
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerPostTweetCancelClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerPostTweetCancelClicked"));
         }
 
         private async void PostTweetClickedShare(object sender, RoutedEventArgs e)
@@ -185,7 +186,7 @@ namespace Emoji8
             }
             
             await ReturnScreenToNormalAfterPopupAsync(PostTweetBorder);
-            Constants.LOGGER.Log(GameText.LOADER.GetString("LoggerPostTweetClicked"));
+            Debug.WriteLine(GameText.LOADER.GetString("LoggerPostTweetClicked"));
         }
 
         private async Task ReturnScreenToNormalAfterPopupAsync(UIElement p)

--- a/Samples/Emoji8/UWP/cs/Emoji8/Services/IntelligenceService.cs
+++ b/Samples/Emoji8/UWP/cs/Emoji8/Services/IntelligenceService.cs
@@ -32,7 +32,6 @@ namespace Emoji8.Services
         public static IntelligenceService Current => _current ?? (_current = new IntelligenceService());
 
         private LearningModel _model = null;
-        private LearningModelDevice _device;
         private LearningModelSession _session;
         private TensorFeatureDescriptor _inputImageDescriptor;
         private TensorFeatureDescriptor _outputTensorDescriptor;


### PR DESCRIPTION
Motivation:
Our internal build pipeline that builds against an nuget feed for prerelease windows SDKs breaks when trying to resolve the SDK reference for the Microsoft Engagement Framework in Emoji8 sample. We didn't gain traction fixing this bug in the nuget feed, but the engagement framework usage isn't important for the purposes of demonstrating WinML functionality since all it does is configure a special sort of logging.
Therefore, this consolidates all logging to the existing debug log in order to remove the reference to the Engagement Framework.

Additionally this PR fixes a warning of an unused LearningModelDevice object.