### PR TITLE
Remove artifical limitation on 5D tensors for GPU 

### DIFF
--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -293,13 +293,6 @@ HRESULT CheckIfModelAndConfigurationsAreSupported(LearningModel& model, const st
         else if (inputFeature.Kind() == LearningModelFeatureKind::Tensor)
         {
             auto tensorFeatureDescriptor = inputFeature.try_as<TensorFeatureDescriptor>();
-            if (tensorFeatureDescriptor.Shape().Size() > 4 && deviceType != DeviceType::CPU)
-            {
-                std::cout << "Input feature " << to_string(inputFeature.Name())
-                          << " shape is too large. GPU path only accepts tensor dimensions <= 4 : "
-                          << tensorFeatureDescriptor.Shape().Size() << std::endl;
-                return E_INVALIDARG;
-            }
 
             // If image as input binding, then the model's tensor inputs should have channel 3 or 1
             if (hasInputBindingImage &&


### PR DESCRIPTION
Fixes this bug: https://github.com/microsoft/Windows-Machine-Learning/issues/324

WinMLRunner rejects 5D tensors, with the message "Input feature input shape is too large. GPU path only accepts tensor dimensions <= 4 : 5", even though DirectML supports 5D tensors (and will likely support more than that too).

This will allow the correct error message to flow through DirectML to WinMLRunner.