### PR TITLE
Add functions to allow ILearningModelFeatureValues to be plumbed through as input through WinMLRunner static library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "Tools/WinML-Dashboard/deps/Netron"]
 	path = Tools/WinMLDashboard/deps/Netron
 	url = https://github.com/lutzroeder/Netron.git
-[submodule "Tools/WinMLRunner/onnxruntime"]
-	path = Tools/WinMLRunner/onnxruntime
-	url = https://github.com/microsoft/onnxruntime.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Tools/WinML-Dashboard/deps/Netron"]
 	path = Tools/WinMLDashboard/deps/Netron
 	url = https://github.com/lutzroeder/Netron.git
+[submodule "Tools/WinMLRunner/onnxruntime"]
+	path = Tools/WinMLRunner/onnxruntime
+	url = https://github.com/microsoft/onnxruntime.git

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -600,10 +600,6 @@ void CommandLineArgs::AddPerformanceFileMetadata(const std::string& key, const s
     cleanedValue.erase(std::remove_copy(value.begin(), value.end(), cleanedValue.begin(), ','), cleanedValue.end());
     m_perfFileMetadata.push_back(std::make_pair(key, cleanedValue));
 }
-
-void CommandLineArgs::AddProtobufInputPath(const std::wstring& protobufFilePath) {
-    m_protobufPaths.push_back(protobufFilePath);
-}
 void CommandLineArgs::AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input)
 {
     m_providedInputFeatureValue.push_back(input);

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -600,3 +600,7 @@ void CommandLineArgs::AddPerformanceFileMetadata(const std::string& key, const s
     cleanedValue.erase(std::remove_copy(value.begin(), value.end(), cleanedValue.begin(), ','), cleanedValue.end());
     m_perfFileMetadata.push_back(std::make_pair(key, cleanedValue));
 }
+
+void CommandLineArgs::AddProtobufInputPath(const std::wstring& protobufFilePath) {
+    m_protobufPaths.push_back(protobufFilePath);
+}

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -604,3 +604,7 @@ void CommandLineArgs::AddPerformanceFileMetadata(const std::string& key, const s
 void CommandLineArgs::AddProtobufInputPath(const std::wstring& protobufFilePath) {
     m_protobufPaths.push_back(protobufFilePath);
 }
+void CommandLineArgs::AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input)
+{
+    m_providedInputFeatureValue.push_back(input);
+}

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -602,5 +602,5 @@ void CommandLineArgs::AddPerformanceFileMetadata(const std::string& key, const s
 }
 void CommandLineArgs::AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input)
 {
-    m_providedInputFeatureValue.push_back(input);
+    m_providedInputFeatureValues.push_back(input);
 }

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -45,7 +45,7 @@ public:
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
 
     const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
-    const std::vector<std::wstring>& ProtobufPaths() const { return m_protobufPaths; }
+    const std::vector<ILearningModelFeatureValue>& ProvidedInputFeatureValues() const { return m_providedInputFeatureValue; }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
@@ -93,11 +93,11 @@ public:
     bool IsGarbageInput() const
     {
         // When there is no image or csv input provided, then garbage input binding is used.
-        return m_imagePaths.empty() && m_csvData.empty() && m_protobufPaths.empty();
+        return m_imagePaths.empty() && m_csvData.empty() && m_providedInputFeatureValue.empty();
     }
     bool IsCSVInput() const { return !m_csvData.empty() && m_imagePaths.empty(); }
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
-    bool ArePredefinedProtobufsProvided() const { return !m_protobufPaths.empty(); }
+    bool InputFeatureValuesProvided() const { return !m_providedInputFeatureValue.empty(); }
     uint32_t NumIterations() const { return m_numIterations; }
     uint32_t NumLoadIterations() const { return m_numLoadIterations; }
     uint32_t NumSessionCreationIterations() const { return m_numSessionIterations; }
@@ -141,7 +141,7 @@ public:
     void SetSessionCreationIterations(const uint32_t iterations) { m_numSessionIterations = iterations; }
     void SetLoadIterations(const uint32_t iterations) { m_numLoadIterations = iterations; }
     void AddPerformanceFileMetadata(const std::string& key, const std::string& value);
-    void AddProtobufInputPath(const std::wstring& protobufFilePath);
+    void AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input);
     void SetGarbageDataMaxValue(const uint32_t value) { m_garbageDataMaxValue = value; }
 
     // Stop iterating when total time of iterations after the first iteration exceeds time limit.
@@ -187,7 +187,7 @@ private:
     std::wstring m_modelFolderPath;
     std::wstring m_modelPath;
     std::vector<std::wstring> m_imagePaths;
-    std::vector<std::wstring> m_protobufPaths;
+    std::vector<ILearningModelFeatureValue> m_providedInputFeatureValue;
     std::wstring m_inputImageFolderPath;
     std::wstring m_csvData;
     std::wstring m_inputData;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -45,6 +45,7 @@ public:
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
 
     const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
+    const std::vector<std::wstring>& ProtobufPaths() const { return m_protobufPaths; }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
@@ -92,11 +93,11 @@ public:
     bool IsGarbageInput() const
     {
         // When there is no image or csv input provided, then garbage input binding is used.
-        return m_imagePaths.empty() && m_csvData.empty();
+        return m_imagePaths.empty() && m_csvData.empty() && m_protobufPaths.empty();
     }
-    bool IsCSVInput() const { return m_imagePaths.empty() && !m_csvData.empty(); }
+    bool IsCSVInput() const { return !m_csvData.empty() && m_imagePaths.empty(); }
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
-
+    bool ArePredefinedProtobufsProvided() const { return !m_protobufPaths.empty(); }
     uint32_t NumIterations() const { return m_numIterations; }
     uint32_t NumLoadIterations() const { return m_numLoadIterations; }
     uint32_t NumSessionCreationIterations() const { return m_numSessionIterations; }
@@ -185,6 +186,7 @@ private:
     std::wstring m_modelFolderPath;
     std::wstring m_modelPath;
     std::vector<std::wstring> m_imagePaths;
+    std::vector<std::wstring> m_protobufPaths;
     std::wstring m_inputImageFolderPath;
     std::wstring m_csvData;
     std::wstring m_inputData;

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -141,6 +141,7 @@ public:
     void SetSessionCreationIterations(const uint32_t iterations) { m_numSessionIterations = iterations; }
     void SetLoadIterations(const uint32_t iterations) { m_numLoadIterations = iterations; }
     void AddPerformanceFileMetadata(const std::string& key, const std::string& value);
+    void AddProtobufInputPath(const std::wstring& protobufFilePath);
     void SetGarbageDataMaxValue(const uint32_t value) { m_garbageDataMaxValue = value; }
 
     // Stop iterating when total time of iterations after the first iteration exceeds time limit.

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -95,7 +95,7 @@ public:
         // When there is no image or csv input provided, then garbage input binding is used.
         return m_imagePaths.empty() && m_csvData.empty() && m_providedInputFeatureValue.empty();
     }
-    bool IsCSVInput() const { return !m_csvData.empty() && m_imagePaths.empty(); }
+    bool IsCSVInput() const { return m_imagePaths.empty() && !m_csvData.empty(); }
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
     bool InputFeatureValuesProvided() const { return !m_providedInputFeatureValue.empty(); }
     uint32_t NumIterations() const { return m_numIterations; }

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -45,7 +45,10 @@ public:
     BitmapInterpolationMode AutoScaleInterpMode() const { return m_autoScaleInterpMode; }
 
     const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
-    const std::vector<ILearningModelFeatureValue>& ProvidedInputFeatureValues() const { return m_providedInputFeatureValue; }
+    const std::vector<ILearningModelFeatureValue>& ProvidedInputFeatureValues() const
+    {
+        return m_providedInputFeatureValue;
+    }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
     const std::wstring& FolderPath() const { return m_modelFolderPath; }
@@ -142,6 +145,7 @@ public:
     void SetLoadIterations(const uint32_t iterations) { m_numLoadIterations = iterations; }
     void AddPerformanceFileMetadata(const std::string& key, const std::string& value);
     void AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input);
+    void ClearProvidedInputFeatureValues() { m_providedInputFeatureValue.clear(); };
     void SetGarbageDataMaxValue(const uint32_t value) { m_garbageDataMaxValue = value; }
 
     // Stop iterating when total time of iterations after the first iteration exceeds time limit.

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -47,7 +47,7 @@ public:
     const std::vector<std::wstring>& ImagePaths() const { return m_imagePaths; }
     const std::vector<ILearningModelFeatureValue>& ProvidedInputFeatureValues() const
     {
-        return m_providedInputFeatureValue;
+        return m_providedInputFeatureValues;
     }
     const std::wstring& CsvPath() const { return m_csvData; }
     const std::wstring& OutputPath() const { return m_perfOutputPath; }
@@ -96,11 +96,11 @@ public:
     bool IsGarbageInput() const
     {
         // When there is no image or csv input provided, then garbage input binding is used.
-        return m_imagePaths.empty() && m_csvData.empty() && m_providedInputFeatureValue.empty();
+        return m_imagePaths.empty() && m_csvData.empty() && m_providedInputFeatureValues.empty();
     }
     bool IsCSVInput() const { return m_imagePaths.empty() && !m_csvData.empty(); }
     bool IsImageInput() const { return !m_imagePaths.empty() && m_csvData.empty(); }
-    bool InputFeatureValuesProvided() const { return !m_providedInputFeatureValue.empty(); }
+    bool InputFeatureValuesProvided() const { return !m_providedInputFeatureValues.empty(); }
     uint32_t NumIterations() const { return m_numIterations; }
     uint32_t NumLoadIterations() const { return m_numLoadIterations; }
     uint32_t NumSessionCreationIterations() const { return m_numSessionIterations; }
@@ -145,7 +145,7 @@ public:
     void SetLoadIterations(const uint32_t iterations) { m_numLoadIterations = iterations; }
     void AddPerformanceFileMetadata(const std::string& key, const std::string& value);
     void AddProvidedInputFeatureValue(const ILearningModelFeatureValue& input);
-    void ClearProvidedInputFeatureValues() { m_providedInputFeatureValue.clear(); };
+    void ClearProvidedInputFeatureValues() { m_providedInputFeatureValues.clear(); };
     void SetGarbageDataMaxValue(const uint32_t value) { m_garbageDataMaxValue = value; }
 
     // Stop iterating when total time of iterations after the first iteration exceeds time limit.
@@ -191,7 +191,7 @@ private:
     std::wstring m_modelFolderPath;
     std::wstring m_modelPath;
     std::vector<std::wstring> m_imagePaths;
-    std::vector<ILearningModelFeatureValue> m_providedInputFeatureValue;
+    std::vector<ILearningModelFeatureValue> m_providedInputFeatureValues;
     std::wstring m_inputImageFolderPath;
     std::wstring m_csvData;
     std::wstring m_inputData;

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -31,15 +31,15 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningMode
         if (inputDataType == InputDataType::Tensor)
         {
             // If CSV data is provided, then every input will contain the same CSV data
-            auto tensorFeature = BindingUtilities::CreateBindableTensor(
-                description, imagePath, inputBindingType, inputDataType, args, iterationNum, colorManagementMode);
+            auto tensorFeature = BindingUtilities::CreateBindableTensor(description, imagePath, inputBindingType, inputDataType,
+                                                                        args, iterationNum, colorManagementMode);
             inputFeatures.push_back(tensorFeature);
         }
         else
         {
             auto imageFeature = BindingUtilities::CreateBindableImage(
-                description, imagePath, inputBindingType, inputDataType,
-                device.LearningModelDevice.Direct3D11Device(), args, iterationNum, colorManagementMode);
+                description, imagePath, inputBindingType, inputDataType, device.LearningModelDevice.Direct3D11Device(),
+                args, iterationNum, colorManagementMode);
             inputFeatures.push_back(imageFeature);
         }
     }
@@ -213,6 +213,9 @@ HRESULT BindInputs(LearningModelBinding& context, const LearningModelSession& se
         std::cout << "Cannot create D3D12 device on client if CPU device type is selected." << std::endl;
         return E_INVALIDARG;
     }
+    bool useInputData = false;
+    bool isGarbageData = args.IsGarbageInput();
+    std::string completionString = "\n";
 
     // Run the binding + evaluate multiple times and average the results
     bool captureIterationPerf = args.IsPerformanceCapture() || args.IsPerIterationCapture();
@@ -226,8 +229,7 @@ HRESULT BindInputs(LearningModelBinding& context, const LearningModelSession& se
     {
         try
         {
-            inputFeatures = GenerateInputFeatures(session.Model(), args, inputBindingType, inputDataType, device,
-                                                  iteration, imagePath);
+            inputFeatures = GenerateInputFeatures(session.Model(), args, inputBindingType, inputDataType, device, iteration, imagePath);
         }
         catch (hresult_error hr)
         {
@@ -236,7 +238,6 @@ HRESULT BindInputs(LearningModelBinding& context, const LearningModelSession& se
             return hr.code();
         }
     }
-
     HRESULT bindInputResult =
         BindInputFeatures(session.Model(), context, inputFeatures, args, output, captureIterationPerf, iteration, profiler);
 

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -28,19 +28,27 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningMode
         {
             colorManagementMode = GetColorManagementMode(model);
         }
-        if (inputDataType == InputDataType::Tensor)
+        if (args.ArePredefinedProtobufsProvided())
         {
-            // If CSV data is provided, then every input will contain the same CSV data
-            auto tensorFeature = BindingUtilities::CreateBindableTensor(description, imagePath, inputBindingType, inputDataType,
-                                                                        args, iterationNum, colorManagementMode);
-            inputFeatures.push_back(tensorFeature);
+            //auto tensorFeature = BindingUtilities::ExtractTensorFromProtobuf(args.ProtobufPaths().at(inputNum));
+            //inputFeatures.push_back(tensorFeature);
         }
         else
         {
-            auto imageFeature = BindingUtilities::CreateBindableImage(
-                description, imagePath, inputBindingType, inputDataType, device.LearningModelDevice.Direct3D11Device(),
-                args, iterationNum, colorManagementMode);
-            inputFeatures.push_back(imageFeature);
+            if (inputDataType == InputDataType::Tensor)
+            {
+                // If CSV data is provided, then every input will contain the same CSV data
+                auto tensorFeature = BindingUtilities::CreateBindableTensor(
+                    description, imagePath, inputBindingType, inputDataType, args, iterationNum, colorManagementMode);
+                inputFeatures.push_back(tensorFeature);
+            }
+            else
+            {
+                auto imageFeature = BindingUtilities::CreateBindableImage(
+                    description, imagePath, inputBindingType, inputDataType,
+                    device.LearningModelDevice.Direct3D11Device(), args, iterationNum, colorManagementMode);
+                inputFeatures.push_back(imageFeature);
+            }
         }
     }
 
@@ -213,9 +221,6 @@ HRESULT BindInputs(LearningModelBinding& context, const LearningModelSession& se
         std::cout << "Cannot create D3D12 device on client if CPU device type is selected." << std::endl;
         return E_INVALIDARG;
     }
-    bool useInputData = false;
-    bool isGarbageData = args.IsGarbageInput();
-    std::string completionString = "\n";
 
     // Run the binding + evaluate multiple times and average the results
     bool captureIterationPerf = args.IsPerformanceCapture() || args.IsPerIterationCapture();

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -1,3 +1,4 @@
+#include "protobufHelpers.h"
 #include "Run.h"
 #include "Common.h"
 #include "OutputHelper.h"
@@ -30,8 +31,9 @@ std::vector<ILearningModelFeatureValue> GenerateInputFeatures(const LearningMode
         }
         if (args.ArePredefinedProtobufsProvided())
         {
-            //auto tensorFeature = BindingUtilities::ExtractTensorFromProtobuf(args.ProtobufPaths().at(inputNum));
-            //inputFeatures.push_back(tensorFeature);
+            inputFeatures.push_back(ProtobufHelpers::LoadTensorFromProtobufFile(
+                args.ProtobufPaths()[inputNum],
+                description.as<TensorFeatureDescriptor>().TensorKind() == TensorKind::Float16));
         }
         else
         {


### PR DESCRIPTION
These functions are only exposed through Commandlineargs class which can be accessed when WinMLRunner is consumed as static library.

It is useful for applications that parsed feature value input outside of WinMLRunner and want to be able to pass it in through WinMLRunner to collect performance.