### PR TITLE
Change winmlrunner to accept LearningModelSessionOptions through run function

### DIFF
--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -124,33 +124,18 @@ HRESULT LoadModel(LearningModel& model, const std::wstring& path, bool capturePe
     return S_OK;
 }
 
-void PopulateSessionOptions(LearningModelSessionOptions& sessionOptions)
-{
-    // Batch Size Override as 1
-    try
-    {
-        sessionOptions.BatchSizeOverride(1);
-    }
-    catch (...)
-    {
-        printf("Batch size override couldn't be set.\n");
-        throw;
-    }
-}
-
 void CreateSessionConsideringSupportForSessionOptions(LearningModelSession& session,
                                                       LearningModel& model,
                                                       Profiler<WINML_MODEL_TEST_PERF>& profiler,
                                                       CommandLineArgs& args,
-                                                      const LearningModelDeviceWithMetadata& learningModelDevice)
+                                                      const LearningModelDeviceWithMetadata& learningModelDevice,
+                                                      const LearningModelSessionOptions& sessionOptions)
 {
     auto statics = get_activation_factory<ApiInformation, IApiInformationStatics>();
     bool isSessionOptionsTypePresent = isSessionOptionsTypePresent =
         statics.IsTypePresent(L"Windows.AI.MachineLearning.LearningModelSessionOptions");
     if (isSessionOptionsTypePresent)
     {
-        LearningModelSessionOptions sessionOptions;
-        PopulateSessionOptions(sessionOptions);
         if (args.IsPerformanceCapture())
         {
             WINML_PROFILING_START(profiler, WINML_MODEL_TEST_PERF::CREATE_SESSION);
@@ -175,8 +160,13 @@ void CreateSessionConsideringSupportForSessionOptions(LearningModelSession& sess
     }
 }
 
-HRESULT CreateSession(LearningModelSession& session, LearningModel& model, const LearningModelDeviceWithMetadata& learningModelDevice,
-                      CommandLineArgs& args, OutputHelper& output, Profiler<WINML_MODEL_TEST_PERF>& profiler)
+HRESULT CreateSession(LearningModelSession& session,
+                      LearningModel& model,
+                      const LearningModelDeviceWithMetadata& learningModelDevice,
+                      CommandLineArgs& args,
+                      OutputHelper& output,
+                      Profiler<WINML_MODEL_TEST_PERF>& profiler,
+                      const LearningModelSessionOptions& sessionOptions)
 {
     if (model == nullptr)
     {
@@ -184,7 +174,7 @@ HRESULT CreateSession(LearningModelSession& session, LearningModel& model, const
     }
     try
     {
-        CreateSessionConsideringSupportForSessionOptions(session, model, profiler, args, learningModelDevice);
+        CreateSessionConsideringSupportForSessionOptions(session, model, profiler, args, learningModelDevice, sessionOptions);
     }
     catch (hresult_error hr)
     {
@@ -535,7 +525,8 @@ void RunConfiguration(CommandLineArgs& args, OutputHelper& output, LearningModel
 }
 int run(CommandLineArgs& args,
         Profiler<WINML_MODEL_TEST_PERF>& profiler,
-        const std::vector<LearningModelDeviceWithMetadata>& deviceList) try
+        const std::vector<LearningModelDeviceWithMetadata>& deviceList,
+        const LearningModelSessionOptions& sessionOptions) try
 {
     // Initialize COM in a multi-threaded environment.
     winrt::init_apartment();
@@ -600,7 +591,7 @@ int run(CommandLineArgs& args,
                             sessionCreationIteration < args.NumSessionCreationIterations();
                             sessionCreationIteration++)
                         {
-                            lastHr = CreateSession(session, model, learningModelDevice,args, output, profiler);
+                            lastHr = CreateSession(session, model, learningModelDevice,args, output, profiler, sessionOptions);
                             if (FAILED(lastHr))
                             {
                                 continue;

--- a/Tools/WinMLRunner/src/Run.h
+++ b/Tools/WinMLRunner/src/Run.h
@@ -3,4 +3,5 @@
 
 int run(CommandLineArgs& args,
     Profiler<WINML_MODEL_TEST_PERF>& profiler,
-    const std::vector<LearningModelDeviceWithMetadata>& deviceList);
+    const std::vector<LearningModelDeviceWithMetadata>& deviceList,
+        const LearningModelSessionOptions& sessionOptions);

--- a/Tools/WinMLRunner/src/main.cpp
+++ b/Tools/WinMLRunner/src/main.cpp
@@ -5,6 +5,20 @@
 #include <codecvt>
 using namespace std;
 
+void PopulateSessionOptions(LearningModelSessionOptions& sessionOptions)
+{
+    // Batch Size Override as 1
+    try
+    {
+        sessionOptions.BatchSizeOverride(1);
+    }
+    catch (...)
+    {
+        printf("Batch size override couldn't be set.\n");
+        throw;
+    }
+}
+
 int main(int argc, char *argv[])
 {
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
@@ -36,7 +50,9 @@ int main(int argc, char *argv[])
         wprintf(error.message().c_str());
         return error.code();
     }
-    int returnCode = run(*commandLineArgs, profiler, deviceList);
+    LearningModelSessionOptions sessionOptions;
+    PopulateSessionOptions(sessionOptions);
+    int returnCode = run(*commandLineArgs, profiler, deviceList, sessionOptions);
     free(commandLineArgs);
     return returnCode;
 }


### PR DESCRIPTION
This will allow apps that consume WinMLRunner static library to be able to modify their own LearningModelSessionOptions. 