### PR TITLE
Change exe naming to MicrosoftMLRunner for x86 nuget build

### DIFF
--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -164,6 +164,7 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)\x86\$(Configuration)\</OutDir>
     <IntDir>x86\$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>MicrosoftMLRunner</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -174,6 +175,7 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)\x86\$(Configuration)\</OutDir>
     <IntDir>x86\$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>MicrosoftMLRunner</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
I forgot to change the exe name for x86 nuget builds to MicrosoftMLRunner.exe from WinMLRunner.exe