### PR TITLE
fix netron loading issue

### DIFF
--- a/Tools/WinMLDashboard/README.md
+++ b/Tools/WinMLDashboard/README.md
@@ -112,6 +112,7 @@ Alternatively, you can build the app from source following the instructions belo
 
 2. `cd Tools/WinMLDashboard`
 3. Run `Git submodule update --init --recursive` to update Netron.
+4. Run `yarn lock-netron-deps` to execute necessary modifications to Netron dependency versions.
 4. Run `yarn` to download dependencies. 
 5. Then, run `yarn electron-prod` to build and start the desktop application, which will launch the Dashboard.
 

--- a/Tools/WinMLDashboard/package.json
+++ b/Tools/WinMLDashboard/package.json
@@ -18,7 +18,8 @@
     "build-cpp": "msbuild src/cpp/DebugRunner.sln",
     "nuget-restore-cpp": "nuget restore src/cpp/DebugRunner.sln",
     "electron-dev": "electron . http://localhost:3000",
-    "electron-prod": "yarn nuget-restore-cpp && yarn build-cpp && yarn build-electron && electron ."
+    "electron-prod": "yarn nuget-restore-cpp && yarn build-cpp && yarn build-electron && electron .",
+    "lock-netron-deps": "cd deps/Netron && yarn upgrade d3@5.16.0"
   },
   "build": {
     "appId": "com.microsoft.dashboard.winml",


### PR DESCRIPTION
When loading a model into the edit view of Netron, the UI rendering crashes with error message: "TypeError: Cannot read property 'transform' of undefined"

After investigation this is due to an issue with Netron's usage of D3. The commit we target of Netron doesn't commit a yarn.lock file and also specifies the latest version for it's D3 dependency. Therefore, our fork of Netron continues to use the latest D3 library as new versions are released. 

In version 6 of D3, the d3.event namespace was removed, and therefore references in this commit of Netron to this namespace causes an undefined property error, thus leading to our issue. This also explains why this bug popped up independent of any code change from netron.

My solution is to add a script to be run at build time that modifies Netron's package.json to use version 5 of D3 instead of the latest.