### PR TITLE
WinMLRunner stack overflow running model due to Profiler<WINML_MODEL_TEST_PERF>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+[Tt]emp/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Tools/WinMLRunner/src/BindingUtilities.cpp
+++ b/Tools/WinMLRunner/src/BindingUtilities.cpp
@@ -444,7 +444,7 @@ namespace BindingUtilities
         WriteType* end = reinterpret_cast<WriteType*>(reinterpret_cast<BYTE*>(data) + sizeInBytes);
         while (begin <= end)
         {
-            *begin = maxValue * static_cast<float>(randomBitsEngine()) / (randomBitsEngine.max)();
+            *begin = static_cast<WriteType>(maxValue * static_cast<float>(randomBitsEngine()) / (randomBitsEngine.max)());
             ++begin;
         }
     }

--- a/Tools/WinMLRunner/src/main.cpp
+++ b/Tools/WinMLRunner/src/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
         std::wcout << hr.message().c_str() << std::endl;
         return hr.code();
     }
-    Profiler<WINML_MODEL_TEST_PERF> profiler;
+    auto profiler = std::make_unique<Profiler<WINML_MODEL_TEST_PERF>>();
     vector<LearningModelDeviceWithMetadata> deviceList;
     try
     {
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
     }
     LearningModelSessionOptions sessionOptions;
     PopulateSessionOptions(sessionOptions);
-    int returnCode = run(*commandLineArgs, profiler, deviceList, sessionOptions);
+    int returnCode = run(*commandLineArgs, *profiler, deviceList, sessionOptions);
     delete commandLineArgs;
     return returnCode;
 }


### PR DESCRIPTION
Running a certain customer model causes a stack overflow in `DmlDevice::CompileGraphPrivate` (OS bug 6332725). WinMLRunner reserves 1MB stack space (which should be enough), but a single local variable allocation uses up 700KBs, leaving all of ONNX Runtime and DML with only 300KBs to execute. Move huge variables to the heap.

(also fix an implicit warning treated as build error and add Temp folder to ignorable directory)