### PR TITLE
Pin flatbuffers version

### DIFF
--- a/Tools/WinMLDashboard/package.json
+++ b/Tools/WinMLDashboard/package.json
@@ -13,13 +13,13 @@
     "test": "mocha",
     "eject": "react-scripts-ts eject",
     "postinstall": "node scripts/postinstall.js && yarn copy-netron",
-    "copy-netron": "yarn --cwd deps/Netron && python deps/copy_netron.py",
+    "copy-netron": "yarn lock-netron-deps && yarn --cwd deps/Netron && python deps/copy_netron.py",
     "build-electron": "react-app-rewired build --scripts-version react-scripts-ts",
     "build-cpp": "msbuild src/cpp/DebugRunner.sln",
     "nuget-restore-cpp": "nuget restore src/cpp/DebugRunner.sln",
     "electron-dev": "electron . http://localhost:3000",
     "electron-prod": "yarn nuget-restore-cpp && yarn build-cpp && yarn build-electron && electron .",
-    "lock-netron-deps": "cd deps/Netron && yarn upgrade d3@5.16.0"
+    "lock-netron-deps": "yarn --cwd deps/Netron upgrade d3@5.16.0 flatbuffers@1.12.0"
   },
   "build": {
     "appId": "com.microsoft.dashboard.winml",

--- a/Tools/WinMLDashboard/src/electronMain.js
+++ b/Tools/WinMLDashboard/src/electronMain.js
@@ -61,8 +61,15 @@ function createWindow() {
 
     mainWindow = new BrowserWindow({
         height: 1000,
-        icon: path.join(__dirname, '../public/winml_icon.ico'),
         width: 1200,
+
+        icon: path.join(__dirname, '../public/winml_icon.ico'),
+        webPreferences: {
+            contextIsolation: false,
+            enableRemoteModule: true,
+            nodeIntegration: true,
+            webviewTag: true,
+        }
     });
     global.mainWindow = mainWindow;
     


### PR DESCRIPTION
Pin flatbuffers version used in Netron (Netron takes the latest version of its dependencies instead of freezing them :( ) and set `nodeIntegration`, `contextIsolation` and other security flags (those are needed since we load Netron in a script tag in the DOM, which on newer versions of electron will block loading modules and sharing state with the loaded script. Though ideally we wouldn't disable security options globally).