### PR TITLE
fix some layout resizing issues and add tooltips in a few spots for hyperlinks

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
@@ -109,8 +109,8 @@
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.0" />
-    <PackageReference Include="Microsoft.ProjectReunion" Version="[0.8.0]">
+    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.1" />
+    <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.4">
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[0.8.0]">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/AllSamplesPage.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/AllSamplesPage.xaml
@@ -1,9 +1,8 @@
 ﻿<Page
     x:Class="WinMLSamplesGallery.AllSamplesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/HomePage.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/HomePage.xaml
@@ -1,9 +1,8 @@
 ﻿<Page
     x:Class="WinMLSamplesGallery.HomePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Image.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Image.xaml
@@ -1,9 +1,8 @@
 ﻿<Page
     x:Class="WinMLSamplesGallery.Image"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Image.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Image.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+﻿using Microsoft.UI.Xaml.Controls;
 
 namespace WinMLSamplesGallery
 {

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml
@@ -32,12 +32,12 @@
             <StackPanel Grid.Row="0" Grid.Column="1" Padding="0,40,40,0" HorizontalAlignment="Right">
                 <TextBlock FontWeight="Bold" FontSize="20">View page code on GitHub</TextBlock>
                 <TextBlock Margin="10,20,0,0" FontSize="16">
-                    <Hyperlink TextDecorations="None" NavigateUri="{x:Bind sampleMetadata.XAMLGithubLink}">
+                    <Hyperlink TextDecorations="None" NavigateUri="{x:Bind sampleMetadata.XAMLGithubLink}" ToolTipService.ToolTip="{x:Bind sampleMetadata.XAMLGithubLink}">
                         XAML Source Code
                     </Hyperlink>
                 </TextBlock>
                 <TextBlock Margin="10,20,0,0" FontSize="16">
-                    <Hyperlink TextDecorations="None" NavigateUri="{x:Bind sampleMetadata.CSharpGithubLink}">
+                    <Hyperlink TextDecorations="None" NavigateUri="{x:Bind sampleMetadata.CSharpGithubLink}" ToolTipService.ToolTip="{x:Bind sampleMetadata.CSharpGithubLink}">
                         C# Source Code
                     </Hyperlink>
                 </TextBlock>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml
@@ -1,10 +1,10 @@
 <Page
     x:Class="WinMLSamplesGallery.SampleBasePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:WinMLSamplesGallery"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Video.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/Video.xaml
@@ -1,9 +1,8 @@
 ﻿<Page
     x:Class="WinMLSamplesGallery.Video"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
@@ -34,6 +34,7 @@
                     faster on average</TextBlock>
             </StackPanel>
         </DataTemplate>
+        <x:String x:Key="WinMLDashboardGithubURL">https://github.com/Microsoft/Windows-Machine-Learning/tree/master/Tools/WinMLDashboard</x:String>
     </Page.Resources>
 
     <StackPanel>
@@ -54,7 +55,7 @@
         <TextBlock Margin="0,10,0,0" MaxWidth="1000" HorizontalAlignment="Left" TextWrapping="Wrap">
             <Bold>Note:</Bold> In order for batching to work, your model must have a value of -1 or a variable name in the batch dimension.
             Additionally, the DATA_BATCH Denotation must be added on the batch dimension. To edit your model you can use tools like
-            <Hyperlink TextDecorations="None" NavigateUri="https://github.com/Microsoft/Windows-Machine-Learning/tree/master/Tools/WinMLDashboard">
+            <Hyperlink TextDecorations="None" NavigateUri="{StaticResource WinMLDashboardGithubURL}" ToolTipService.ToolTip="{StaticResource WinMLDashboardGithubURL}">
                 WinML Dashboard.
             </Hyperlink>
         </TextBlock>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
@@ -39,7 +39,7 @@
 
     <StackPanel>
         <TextBlock FontWeight="Bold" FontSize="20" Margin="0,40,0,0" TextWrapping="Wrap">Set the BatchSizeOverride property on your LearningModelSessionOptions object</TextBlock>
-        <StackPanel Margin="0,15,0,0" HorizontalAlignment="Left" MaxWidth="1000" Background="#F6F6F6" BorderBrush="#dbdbdb" BorderThickness="1" CornerRadius="5" Padding="15,20,0,22">
+        <StackPanel Margin="0,15,0,0" HorizontalAlignment="Left" MaxWidth="1000" Background="#F6F6F6" BorderBrush="#dbdbdb" BorderThickness="1" CornerRadius="5" Padding="15,20,15,22">
             <TextBlock FontSize="16">
             <Span Foreground="#3562FF">var</Span> <Span Foreground="#1684B2">options</Span> = <Span Foreground="#3562FF">new</Span> <Span Foreground="#1F9D00">LearningModelSessionOptions</Span>();
             </TextBlock>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml
@@ -1,12 +1,11 @@
 <Page
     x:Class="WinMLSamplesGallery.Samples.Batching"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local_controls="using:WinMLSamplesGallery.Controls"
     xmlns:local_samples="using:WinMLSamplesGallery.Samples"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     FontFamily="Arial">
 
@@ -39,7 +38,7 @@
 
     <StackPanel>
         <TextBlock FontWeight="Bold" FontSize="20" Margin="0,40,0,0" TextWrapping="Wrap">Set the BatchSizeOverride property on your LearningModelSessionOptions object</TextBlock>
-        <StackPanel Margin="0,15,0,0" HorizontalAlignment="Left" Width="1000" Background="#F6F6F6" BorderBrush="#dbdbdb" BorderThickness="1" CornerRadius="5" Padding="15,20,0,22">
+        <StackPanel Margin="0,15,0,0" HorizontalAlignment="Left" MaxWidth="1000" Background="#F6F6F6" BorderBrush="#dbdbdb" BorderThickness="1" CornerRadius="5" Padding="15,20,0,22">
             <TextBlock FontSize="16">
             <Span Foreground="#3562FF">var</Span> <Span Foreground="#1684B2">options</Span> = <Span Foreground="#3562FF">new</Span> <Span Foreground="#1F9D00">LearningModelSessionOptions</Span>();
             </TextBlock>
@@ -52,15 +51,12 @@
             <Span Foreground="#1684B2">device</Span>, <Span Foreground="#1684B2">options</Span>);
             </TextBlock>
         </StackPanel>
-        <TextBlock Margin="0,10,0,0" Width="1000" HorizontalAlignment="Left" TextTrimming="None" Height="20">
+        <TextBlock Margin="0,10,0,0" MaxWidth="1000" HorizontalAlignment="Left" TextWrapping="Wrap">
             <Bold>Note:</Bold> In order for batching to work, your model must have a value of -1 or a variable name in the batch dimension.
-            Additionally, the DATA_BATCH Denotation
-        </TextBlock>
-        <TextBlock>
-        must be added on the batch dimension. To edit your model you can use tools like
-        <Hyperlink TextDecorations="None" NavigateUri="https://github.com/Microsoft/Windows-Machine-Learning/tree/master/Tools/WinMLDashboard">
-            WinML Dashboard.
-        </Hyperlink>
+            Additionally, the DATA_BATCH Denotation must be added on the batch dimension. To edit your model you can use tools like
+            <Hyperlink TextDecorations="None" NavigateUri="https://github.com/Microsoft/Windows-Machine-Learning/tree/master/Tools/WinMLDashboard">
+                WinML Dashboard.
+            </Hyperlink>
         </TextBlock>
         <TextBlock FontWeight="Bold" FontSize="20" Margin="0,60,0,0" TextWrapping="Wrap">
             Compare inference runtimes with and without batching on the CPU and GPU (if available)
@@ -94,7 +90,7 @@
                 </Button.Resources>
             </Button>
         </StackPanel>
-        <TextBlock Margin="0,10,0,0" Width="1000" HorizontalAlignment="Left" TextTrimming="None" Height="20">
+        <TextBlock Margin="0,10,0,0" MaxWidth="1000" HorizontalAlignment="Left" TextWrapping="Wrap">
         <Bold>Note:</Bold> Performance differences are usually much more apparent when using the GPU.
         </TextBlock>
         <StackPanel x:Name="LoadingContainer" Visibility="Collapsed" Orientation="Horizontal" Margin="0,30,0,0">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
+using Microsoft.AI.MachineLearning;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Storage;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Windows.Graphics.Imaging;
 using Windows.Media;
-using Microsoft.AI.MachineLearning;
-using System.Threading.Tasks;
+using Windows.Storage;
 
 namespace WinMLSamplesGallery.Samples
 {

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml
@@ -1,12 +1,11 @@
 ﻿<Page
     x:Class="WinMLSamplesGallery.Samples.ImageClassifier"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinMLSamplesGallery"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local_controls="using:WinMLSamplesGallery.Controls"
     xmlns:local_samples="using:WinMLSamplesGallery.Samples"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Microsoft.AI.MachineLearning;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
-using Windows.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
 using Windows.Graphics.Imaging;
 using Windows.Media;
-using Microsoft.AI.MachineLearning;
+using Windows.Storage;
 using WinMLSamplesGallery.Common;
 using WinMLSamplesGallery.Controls;
-using Windows.Foundation.Metadata;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation.Collections;
-using Windows.Foundation;
 
 namespace WinMLSamplesGallery.Samples
 {

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -131,9 +131,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.0" />
-    <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.0" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.1" />
+    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.1" />
+    <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 


### PR DESCRIPTION
When resizing the app smaller some text was getting cut off; now it reflows appropriately. 
Also this change adds tooltips to a few hyperlinks so people can see where the link goes before clicking it. 
Lastly, I ran visual studio's remove and sort functionality for namespaces and usings.