### PR TITLE
use percent for probability instead of scientific notation

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
@@ -440,7 +440,7 @@ namespace WinMLSamplesGallery.Samples
                     new Controls.Prediction {
                         Index = zippedResult.First,
                         Name = zippedResult.Second.First.Trim(new char[] { ',' }),
-                        Probability = zippedResult.Second.Second.ToString("E4")
+                        Probability = zippedResult.Second.Second.ToString("P")
                     });
             InferenceResults.ItemsSource = results;
             InferenceResults.SelectedIndex = 0;


### PR DESCRIPTION
Change the prediction result from scientific notation to percentages because it's easier to read.