### PR TITLE
Publish Samples Gallery MSIX Bundled From Github Public Samples Pipeline

### DIFF
--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
@@ -145,23 +145,23 @@ steps:
 
   # TODO: Add previously failing build tasks
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-      Contents: |
-        **\SamplesTest\**
-        **\AppPackages\**
-    condition: succeededOrFailed()
+  # - task: CopyFiles@2
+  #   inputs:
+  #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+  #     sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+  #     Contents: |
+  #       **\SamplesTest\**
+  #       **\AppPackages\**
+  #   condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-      Contents: |
-        ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
-        SqueezeNetObjectDetection\*
-    condition: succeededOrFailed()
+  # - task: CopyFiles@2
+  #   inputs:
+  #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+  #     sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+  #     Contents: |
+  #       ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
+  #       SqueezeNetObjectDetection\*
+  #   condition: succeededOrFailed()
 
   - task: CopyFiles@2
     inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -49,11 +49,11 @@ pr:
     - Tools
 
 steps: 
-  - task: PowerShell@2
-    displayName: 'Clone Git Submodules'
-    inputs:
-      targetType: inline
-      script: git submodule update --init --recursive
+  # - task: PowerShell@2
+  #   displayName: 'Clone Git Submodules'
+  #   inputs:
+  #     targetType: inline
+  #     script: git submodule update --init --recursive
 
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet 5.11.0'
@@ -65,19 +65,6 @@ steps:
     inputs:
       targetType: inline
       script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
-
-  - task: MsixPackaging@1
-    inputs:
-      outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
-      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      clean: false
-      generateBundle: true
-      buildConfiguration: 'debug'
-      updateAppVersion: false
-      appPackageDistributionMode: 'SideloadOnly'
-      msbuildLocationMethod: 'version'
-      msbuildVersion: 'latest'
-      msbuildArchitecture: 'x86'
 
   # - task: PowerShell@1
   #   displayName: OpenCV - Configure CMake
@@ -109,15 +96,28 @@ steps:
   #     createLogFile: true
   #   condition: succeededOrFailed()
 
-  # - task: PowerShell@2
-  #   displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-  #   inputs:
-  #     targetType: 'inline'
-  #     script: |
-  #       $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-  #       $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-  #       $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-  #       nuget restore $csproj -SolutionDirectory $solution_dir
+  - task: PowerShell@2
+    displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+        $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+        $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+        nuget restore $csproj -SolutionDirectory $solution_dir
+
+  - task: MsixPackaging@1
+    inputs:
+      outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
+      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+      clean: false
+      generateBundle: true
+      buildConfiguration: 'debug'
+      updateAppVersion: false
+      appPackageDistributionMode: 'SideloadOnly'
+      msbuildLocationMethod: 'version'
+      msbuildVersion: 'latest'
+      msbuildArchitecture: 'x86'
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -119,17 +119,22 @@ steps:
   #     msbuildVersion: 'latest'
   #     msbuildArchitecture: 'x86'
 
-  - task: VSBuild@1
-    displayName: 'Build And Publish WinMLSamplesGallery'
+  # - task: VSBuild@1
+  #   displayName: 'Build And Publish WinMLSamplesGallery'
+  #   inputs:
+  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+  #     vsVersion: "16.0"
+  #     msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+  #     platform: '$(BuildPlatform)'
+  #     configuration: '$(BuildConfiguration)'
+  #     msbuildArchitecture: x64
+  #     createLogFile: true
+  #   condition: succeededOrFailed()      
+
+  - task: PowerShell@2
     inputs:
-      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86" /p:Configuration=Release /p:Platform=x64 /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-      platform: '$(BuildPlatform)'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()      
+      targetType: 'inline'
+      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -66,57 +66,70 @@ steps:
       targetType: inline
       script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
 
-  - task: PowerShell@1
-    displayName: OpenCV - Configure CMake
+  - task: MsixPackaging@1
     inputs:
-      scriptName: external/tools/CMakeConfigureOpenCV.ps1
-      workingDirectory: $(System.ArtifactsDirectory)
-      arguments: >
+      outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
+      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+      clean: false
+      generateBundle: true
+      buildConfiguration: 'debug'
+      updateAppVersion: false
+      appPackageDistributionMode: 'SideloadOnly'
+      msbuildLocationMethod: 'version'
+      msbuildVersion: 'latest'
+      msbuildArchitecture: 'x86'
+
+  # - task: PowerShell@1
+  #   displayName: OpenCV - Configure CMake
+  #   inputs:
+  #     scriptName: external/tools/CMakeConfigureOpenCV.ps1
+  #     workingDirectory: $(System.ArtifactsDirectory)
+  #     arguments: >
         -Architecture $(BuildPlatform)
 
-  - task: VSBuild@1
-    displayName: 'OpenCV - Build'
-    inputs:
-      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()
+  # - task: VSBuild@1
+  #   displayName: 'OpenCV - Build'
+  #   inputs:
+  #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
+  #     vsVersion: "16.0"
+  #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+  #     configuration: '$(BuildConfiguration)'
+  #     msbuildArchitecture: x64
+  #     createLogFile: true
+  #   condition: succeededOrFailed()
     
-  - task: VSBuild@1
-    displayName: 'OpenCV - Install'
-    inputs:
-      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()
+  # - task: VSBuild@1
+  #   displayName: 'OpenCV - Install'
+  #   inputs:
+  #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
+  #     vsVersion: "16.0"
+  #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+  #     configuration: '$(BuildConfiguration)'
+  #     msbuildArchitecture: x64
+  #     createLogFile: true
+  #   condition: succeededOrFailed()
 
-  - task: PowerShell@2
-    displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-        $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-        $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-        nuget restore $csproj -SolutionDirectory $solution_dir
+  # - task: PowerShell@2
+  #   displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+  #       $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+  #       $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+  #       nuget restore $csproj -SolutionDirectory $solution_dir
 
-  - task: VSBuild@1
-    displayName: 'Build WinMLSamplesGallery'
-    inputs:
-      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-      platform: '$(BuildPlatform)'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()
+  # - task: VSBuild@1
+  #   displayName: 'Build WinMLSamplesGallery'
+  #   inputs:
+  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+  #     vsVersion: "16.0"
+  #     msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+  #     platform: '$(BuildPlatform)'
+  #     configuration: '$(BuildConfiguration)'
+  #     msbuildArchitecture: x64
+  #     createLogFile: true
+  #   condition: succeededOrFailed()
 
   # TODO: Add previously failing build tasks
 

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -107,7 +107,19 @@ steps:
         nuget restore $csproj -SolutionDirectory $solution_dir
 
   - task: VSBuild@1
-    displayName: 'Build And Publish WinMLSamplesGallery'
+    displayName: 'Build WinMLSamplesGallery Debug'
+    inputs:
+      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+      vsVersion: "16.0"
+      msbuildArgs: '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
+      createLogFile: true
+    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Release'))
+
+  - task: VSBuild@1
+    displayName: 'Build And Publish WinMLSamplesGallery Release'
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
@@ -116,7 +128,7 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Debug'))
 
   # TODO: Add previously failing build tasks
 
@@ -144,7 +156,7 @@ steps:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
       sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
       contents: '**\*'
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Release'))
 
   - task: CopyFiles@2
     inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -110,7 +110,7 @@ steps:
     inputs:
       outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      clean: false
+      clean: true
       generateBundle: true
       buildConfiguration: 'debug'
       updateAppVersion: false
@@ -118,6 +118,7 @@ steps:
       msbuildLocationMethod: 'version'
       msbuildVersion: 'latest'
       msbuildArchitecture: 'x86'
+      
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -134,7 +134,7 @@ steps:
   - task: PowerShell@2
     inputs:
       targetType: 'inline'
-      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -85,7 +85,7 @@ steps:
   #     scriptName: external/tools/CMakeConfigureOpenCV.ps1
   #     workingDirectory: $(System.ArtifactsDirectory)
   #     arguments: >
-        -Architecture $(BuildPlatform)
+        # -Architecture $(BuildPlatform)
 
   # - task: VSBuild@1
   #   displayName: 'OpenCV - Build'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -116,7 +116,7 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
 
   - task: VSBuild@1
     displayName: 'Build And Publish WinMLSamplesGallery Release'
@@ -128,7 +128,7 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
+    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
   # TODO: Add previously failing build tasks
 

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -96,29 +96,40 @@ steps:
   #     createLogFile: true
   #   condition: succeededOrFailed()
 
-  - task: PowerShell@2
-    displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-        $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-        $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-        nuget restore $csproj -SolutionDirectory $solution_dir
+  # - task: PowerShell@2
+  #   displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: |
+  #       $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+  #       $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+  #       $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+  #       nuget restore $csproj -SolutionDirectory $solution_dir
 
-  - task: MsixPackaging@1
+  # - task: MsixPackaging@1
+  #   inputs:
+  #     outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
+  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+  #     clean: true
+  #     generateBundle: true
+  #     buildConfiguration: 'debug'
+  #     updateAppVersion: false
+  #     appPackageDistributionMode: 'SideloadOnly'
+  #     msbuildLocationMethod: 'version'
+  #     msbuildVersion: 'latest'
+  #     msbuildArchitecture: 'x86'
+
+  - task: VSBuild@1
+    displayName: 'Build And Publish WinMLSamplesGallery'
     inputs:
-      outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      clean: true
-      generateBundle: true
-      buildConfiguration: 'debug'
-      updateAppVersion: false
-      appPackageDistributionMode: 'SideloadOnly'
-      msbuildLocationMethod: 'version'
-      msbuildVersion: 'latest'
-      msbuildArchitecture: 'x86'
-      
+      vsVersion: "16.0"
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" /p:AppxBundlePlatforms=x86|x64 /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
+      createLogFile: true
+    condition: succeededOrFailed()      
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86" /p:Configuration=Release /p:Platform=x64 /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -134,7 +134,7 @@ steps:
   - task: PowerShell@2
     inputs:
       targetType: 'inline'
-      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -165,6 +165,13 @@ steps:
 
   - task: CopyFiles@2
     inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)\AppPackages'
+      sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
+      contents: '**\*'
+    condition: succeededOrFailed()
+
+  - task: CopyFiles@2
+    inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
       sourceFolder: 'SharedContent'
       contents: '**\*'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -96,15 +96,15 @@ steps:
   #     createLogFile: true
   #   condition: succeededOrFailed()
 
-  # - task: PowerShell@2
-  #   displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-  #   inputs:
-  #     targetType: 'inline'
-  #     script: |
-  #       $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-  #       $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-  #       $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-  #       nuget restore $csproj -SolutionDirectory $solution_dir
+  - task: PowerShell@2
+    displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+        $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+        $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+        nuget restore $csproj -SolutionDirectory $solution_dir
 
   # - task: MsixPackaging@1
   #   inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -116,7 +116,7 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Release'))
+    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
   - task: VSBuild@1
     displayName: 'Build And Publish WinMLSamplesGallery Release'
@@ -128,7 +128,7 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Debug'))
+    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
 
   # TODO: Add previously failing build tasks
 
@@ -156,7 +156,7 @@ steps:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
       sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
       contents: '**\*'
-    condition: and(succeededOrFailed(), eq($(BuildConfiguration), 'Release'))
+    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
   - task: CopyFiles@2
     inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -111,7 +111,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
@@ -123,7 +123,7 @@ steps:
   - task: CopyFiles@2
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildConfiguration)\'
       Contents: |
         **\SamplesTest\**
         **\AppPackages\**
@@ -132,7 +132,7 @@ steps:
   - task: CopyFiles@2
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
       Contents: |
         ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
         SqueezeNetObjectDetection\*

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -111,7 +111,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+      msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -119,22 +119,22 @@ steps:
   #     msbuildVersion: 'latest'
   #     msbuildArchitecture: 'x86'
 
-  # - task: VSBuild@1
-  #   displayName: 'Build And Publish WinMLSamplesGallery'
-  #   inputs:
-  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-  #     vsVersion: "16.0"
-  #     msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-  #     platform: '$(BuildPlatform)'
-  #     configuration: '$(BuildConfiguration)'
-  #     msbuildArchitecture: x64
-  #     createLogFile: true
-  #   condition: succeededOrFailed()      
-
-  - task: PowerShell@2
+  - task: VSBuild@1
+    displayName: 'Build And Publish WinMLSamplesGallery'
     inputs:
-      targetType: 'inline'
-      script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+      vsVersion: "16.0"
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
+      createLogFile: true
+    condition: succeededOrFailed()      
+
+  # - task: PowerShell@2
+  #   inputs:
+  #     targetType: 'inline'
+  #     script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
 
   # - task: VSBuild@1
   #   displayName: 'Build WinMLSamplesGallery'
@@ -170,7 +170,7 @@ steps:
 
   - task: CopyFiles@2
     inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\AppPackages'
+      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
       sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
       contents: '**\*'
     condition: succeededOrFailed()

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -123,7 +123,7 @@ steps:
   - task: CopyFiles@2
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildConfiguration)\'
+      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
       Contents: |
         **\SamplesTest\**
         **\AppPackages\**

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -49,11 +49,11 @@ pr:
     - Tools
 
 steps: 
-  # - task: PowerShell@2
-  #   displayName: 'Clone Git Submodules'
-  #   inputs:
-  #     targetType: inline
-  #     script: git submodule update --init --recursive
+  - task: PowerShell@2
+    displayName: 'Clone Git Submodules'
+    inputs:
+      targetType: inline
+      script: git submodule update --init --recursive
 
   - task: NuGetToolInstaller@1
     displayName: 'Install NuGet 5.11.0'
@@ -66,35 +66,35 @@ steps:
       targetType: inline
       script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
 
-  # - task: PowerShell@1
-  #   displayName: OpenCV - Configure CMake
-  #   inputs:
-  #     scriptName: external/tools/CMakeConfigureOpenCV.ps1
-  #     workingDirectory: $(System.ArtifactsDirectory)
-  #     arguments: >
-        # -Architecture $(BuildPlatform)
+  - task: PowerShell@1
+    displayName: OpenCV - Configure CMake
+    inputs:
+      scriptName: external/tools/CMakeConfigureOpenCV.ps1
+      workingDirectory: $(System.ArtifactsDirectory)
+      arguments: >
+        -Architecture $(BuildPlatform)
 
-  # - task: VSBuild@1
-  #   displayName: 'OpenCV - Build'
-  #   inputs:
-  #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
-  #     vsVersion: "16.0"
-  #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-  #     configuration: '$(BuildConfiguration)'
-  #     msbuildArchitecture: x64
-  #     createLogFile: true
-  #   condition: succeededOrFailed()
+  - task: VSBuild@1
+    displayName: 'OpenCV - Build'
+    inputs:
+      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
+      vsVersion: "16.0"
+      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
+      createLogFile: true
+    condition: succeededOrFailed()
     
-  # - task: VSBuild@1
-  #   displayName: 'OpenCV - Install'
-  #   inputs:
-  #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
-  #     vsVersion: "16.0"
-  #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-  #     configuration: '$(BuildConfiguration)'
-  #     msbuildArchitecture: x64
-  #     createLogFile: true
-  #   condition: succeededOrFailed()
+  - task: VSBuild@1
+    displayName: 'OpenCV - Install'
+    inputs:
+      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
+      vsVersion: "16.0"
+      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
+      createLogFile: true
+    condition: succeededOrFailed()
 
   - task: PowerShell@2
     displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
@@ -106,19 +106,6 @@ steps:
         $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
         nuget restore $csproj -SolutionDirectory $solution_dir
 
-  # - task: MsixPackaging@1
-  #   inputs:
-  #     outputPath: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
-  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-  #     clean: true
-  #     generateBundle: true
-  #     buildConfiguration: 'debug'
-  #     updateAppVersion: false
-  #     appPackageDistributionMode: 'SideloadOnly'
-  #     msbuildLocationMethod: 'version'
-  #     msbuildVersion: 'latest'
-  #     msbuildArchitecture: 'x86'
-
   - task: VSBuild@1
     displayName: 'Build And Publish WinMLSamplesGallery'
     inputs:
@@ -129,44 +116,27 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
       createLogFile: true
-    condition: succeededOrFailed()      
-
-  # - task: PowerShell@2
-  #   inputs:
-  #     targetType: 'inline'
-  #     script: 'C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln /p:Configuration=$(BuildConfiguration) /p:Platform=$(BuildPlatform) /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
-
-  # - task: VSBuild@1
-  #   displayName: 'Build WinMLSamplesGallery'
-  #   inputs:
-  #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-  #     vsVersion: "16.0"
-  #     msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-  #     platform: '$(BuildPlatform)'
-  #     configuration: '$(BuildConfiguration)'
-  #     msbuildArchitecture: x64
-  #     createLogFile: true
-  #   condition: succeededOrFailed()
+    condition: succeededOrFailed()
 
   # TODO: Add previously failing build tasks
 
-  # - task: CopyFiles@2
-  #   inputs:
-  #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-  #     sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-  #     Contents: |
-  #       **\SamplesTest\**
-  #       **\AppPackages\**
-  #   condition: succeededOrFailed()
+  - task: CopyFiles@2
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+      Contents: |
+        **\SamplesTest\**
+        **\AppPackages\**
+    condition: succeededOrFailed()
 
-  # - task: CopyFiles@2
-  #   inputs:
-  #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-  #     sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-  #     Contents: |
-  #       ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
-  #       SqueezeNetObjectDetection\*
-  #   condition: succeededOrFailed()
+  - task: CopyFiles@2
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+      sourceFolder: '$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+      Contents: |
+        ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
+        SqueezeNetObjectDetection\*
+    condition: succeededOrFailed()
 
   - task: CopyFiles@2
     inputs:
@@ -176,6 +146,7 @@ steps:
     condition: succeededOrFailed()
 
   - task: CopyFiles@2
+    displayName: 'Copy App Packages'
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
       sourceFolder: 'SharedContent'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -139,6 +139,7 @@ steps:
     condition: succeededOrFailed()
 
   - task: CopyFiles@2
+    displayName: 'Copy App Packages'
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
       sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
@@ -146,7 +147,6 @@ steps:
     condition: succeededOrFailed()
 
   - task: CopyFiles@2
-    displayName: 'Copy App Packages'
     inputs:
       targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
       sourceFolder: 'SharedContent'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" /p:AppxBundlePlatforms=x86|x64 /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -124,7 +124,7 @@ steps:
     inputs:
       solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
       vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+      msbuildArgs: '/p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\WinMLSamplesGallery\ /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundleOutput=Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages" "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64


### PR DESCRIPTION
This change causes the Samples Gallery to be published as a build artifact from the Github Public Samples Build Pipeline Release Builds.
- The location of the app bundle is in the AppPackages folder located inside the specific configuration and architecture in the artifacts (e.g. x64/Debug/AppPackages)
- The msixbundle can be downloaded from the above folder but it is unsigned so it will need to be signed locally before the gallery can be installed from the bundle.