### PR TITLE
Extend Github Public Samples Build Timeout to 90 minutes

### DIFF
--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -1,34 +1,17 @@
 resources:
-
 - repo: self
   clean: true
-
-variables:
-  SamplesBin: SamplesBin
-  WINDOWS_WINMD: C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd
-  WindowsTargetPlatformVersion: 10.0.18362.0
-
-strategy:
-  maxParallel: 8
-  matrix:
-    Release_x64:
-      BuildPlatform: x64
-      BuildConfiguration: Release
-    Debug_x64:
-      BuildPlatform: x64
-      BuildConfiguration: Debug
-    Release_x86:
-      BuildPlatform: x86
-      BuildConfiguration: Release
-    Debug_x86:
-      BuildPlatform: x86
-      BuildConfiguration: Debug
 
 pool:
     vmImage: 'windows-latest'
 # pool:
 #   name: DirectML_BuildPool
 #  demands: agent.osversion -equals 10.0.17763
+
+variables:
+  SamplesBin: SamplesBin
+  WINDOWS_WINMD: C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd
+  WindowsTargetPlatformVersion: 10.0.18362.0
 
 # CI trigger
 trigger:
@@ -49,126 +32,146 @@ pr:
     exclude:
     - Tools
 
-steps: 
-  - task: PowerShell@2
-    displayName: 'Clone Git Submodules'
-    inputs:
-      targetType: inline
-      script: git submodule update --init --recursive
+jobs:
+- job: Samples_Gallery_Build
+  timeoutInMinutes: 90
 
-  - task: NuGetToolInstaller@1
-    displayName: 'Install NuGet 5.11.0'
-    inputs:
-      versionSpec: '5.11.0'
+  strategy:
+    maxParallel: 8
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
 
-  - task: PowerShell@2
-    displayName: 'Install the win 10 sdk v18362 if necessary'
-    inputs:
-      targetType: inline
-      script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
+  steps: 
+    - task: PowerShell@2
+      displayName: 'Clone Git Submodules'
+      inputs:
+        targetType: inline
+        script: git submodule update --init --recursive
 
-  - task: PowerShell@1
-    displayName: OpenCV - Configure CMake
-    inputs:
-      scriptName: external/tools/CMakeConfigureOpenCV.ps1
-      workingDirectory: $(System.ArtifactsDirectory)
-      arguments: >
-        -Architecture $(BuildPlatform)
+    - task: NuGetToolInstaller@1
+      displayName: 'Install NuGet 5.11.0'
+      inputs:
+        versionSpec: '5.11.0'
 
-  - task: VSBuild@1
-    displayName: 'OpenCV - Build'
-    inputs:
-      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()
-    
-  - task: VSBuild@1
-    displayName: 'OpenCV - Install'
-    inputs:
-      solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: succeededOrFailed()
+    - task: PowerShell@2
+      displayName: 'Install the win 10 sdk v18362 if necessary'
+      inputs:
+        targetType: inline
+        script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
 
-  - task: PowerShell@2
-    displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-        $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-        $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-        nuget restore $csproj -SolutionDirectory $solution_dir
+    - task: PowerShell@1
+      displayName: OpenCV - Configure CMake
+      inputs:
+        scriptName: external/tools/CMakeConfigureOpenCV.ps1
+        workingDirectory: $(System.ArtifactsDirectory)
+        arguments: >
+          -Architecture $(BuildPlatform)
 
-  - task: VSBuild@1
-    displayName: 'Build WinMLSamplesGallery Debug'
-    inputs:
-      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-      platform: '$(BuildPlatform)'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
+    - task: VSBuild@1
+      displayName: 'OpenCV - Build'
+      inputs:
+        solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
+        vsVersion: "16.0"
+        msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
+      
+    - task: VSBuild@1
+      displayName: 'OpenCV - Install'
+      inputs:
+        solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
+        vsVersion: "16.0"
+        msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
-  - task: VSBuild@1
-    displayName: 'Build And Publish WinMLSamplesGallery Release'
-    inputs:
-      solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-      vsVersion: "16.0"
-      msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
-      platform: '$(BuildPlatform)'
-      configuration: '$(BuildConfiguration)'
-      msbuildArchitecture: x64
-      createLogFile: true
-    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+    - task: PowerShell@2
+      displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+          $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+          $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+          nuget restore $csproj -SolutionDirectory $solution_dir
 
-  # TODO: Add previously failing build tasks
+    - task: VSBuild@1
+      displayName: 'Build WinMLSamplesGallery Debug'
+      inputs:
+        solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-      Contents: |
-        **\SamplesTest\**
-        **\AppPackages\**
-    condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build And Publish WinMLSamplesGallery Release'
+      inputs:
+        solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-      sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-      Contents: |
-        ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
-        SqueezeNetObjectDetection\*
-    condition: succeededOrFailed()
+    # TODO: Add previously failing build tasks
 
-  - task: CopyFiles@2
-    displayName: 'Copy App Packages'
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
-      sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
-      contents: '**\*'
-    condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+        Contents: |
+          **\SamplesTest\**
+          **\AppPackages\**
+      condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
-      sourceFolder: 'SharedContent'
-      contents: '**\*'
-    condition: succeededOrFailed()
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+        Contents: |
+          ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
+          SqueezeNetObjectDetection\*
+      condition: succeededOrFailed()
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Samples'
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: WinMLPublicSamples
-    condition: succeededOrFailed()
+    - task: CopyFiles@2
+      displayName: 'Copy App Packages'
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
+        sourceFolder: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/AppPackages'
+        contents: '**\*'
+      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
+        sourceFolder: 'SharedContent'
+        contents: '**\*'
+      condition: succeededOrFailed()
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: Samples'
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: WinMLPublicSamples
+      condition: succeededOrFailed()

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -33,7 +33,7 @@ pr:
     - Tools
 
 jobs:
-- job: Samples_Gallery_Build
+- job: Public_Samples_Build
   timeoutInMinutes: 90
 
   strategy:


### PR DESCRIPTION
This change extends the GitHub Public Samples Build Timeout to 90 minutes to counteract the increased execution time due to the OpenCV Build Task
- All the tasks were placed underneath a job so that the timeoutInMinutes flag could be added globally