### PR TITLE
Use batched SqueezeNet model in batching sample

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
@@ -106,7 +106,7 @@ namespace WinMLSamplesGallery.Samples
 
         private async Task CreateSessions(int batchSizeOverride)
         {
-            var modelPath = "ms-appx:///Models/squeezenet1.1-7.onnx";
+            var modelPath = "ms-appx:///Models/squeezenet1.1-7-batched.onnx";
             nonBatchingSession_ = await CreateLearningModelSession(modelPath);
             batchingSession_ = await CreateLearningModelSession(modelPath, batchSizeOverride);
         }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -153,6 +153,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<Folder Include="Models\" />  
     <Folder Include="LargeModels\" />
   </ItemGroup>
 

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -153,7 +153,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<Folder Include="Models\" />  
+    <Folder Include="Models\" />
     <Folder Include="LargeModels\" />
   </ItemGroup>
 

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -25,6 +25,7 @@
     <None Remove="AllSamplesPage.xaml" />
     <None Remove="Controls\PerformanceMonitor.xaml" />
     <None Remove="HomePage.xaml" />
+    <None Remove="Models\squeezenet1.1-7-batched.onnx" />
 	<None Remove="SamplesGrid.xaml" />
 	<None Remove="SampleBasePage.xaml" />
     <None Remove="Image.xaml" />
@@ -36,6 +37,7 @@
     <None Remove="Video.xaml" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Models\squeezenet1.1-7-batched.onnx" />
     <Content Include="SampleMetadata\SampleMetadata.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -151,7 +153,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
     <Folder Include="LargeModels\" />
   </ItemGroup>
 


### PR DESCRIPTION
This change adds the batched SqueezeNet model to the models folder in the WinMLSamplesGallery and updates the batching sample to use that model.
- This also fixes the issues with the batching sample crashing