### PR TITLE
Add old samples back to the GitHub Public Samples Build

### DIFF
--- a/Samples/MNIST/UWP/cs/MNIST_Demo.csproj
+++ b/Samples/MNIST/UWP/cs/MNIST_Demo.csproj
@@ -136,7 +136,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AI.MachineLearning">
-      <Version>1.5.2</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.9</Version>

--- a/Samples/MNIST/UWP/cs/MNIST_Demo.sln
+++ b/Samples/MNIST/UWP/cs/MNIST_Demo.sln
@@ -16,9 +16,9 @@ Global
 		Release_Inbox|ARM = Release_Inbox|ARM
 		Release_Inbox|x64 = Release_Inbox|x64
 		Release_Inbox|x86 = Release_Inbox|x86
-		Release_Nuget|ARM = Release_Nuget|ARM
-		Release_Nuget|x64 = Release_Nuget|x64
-		Release_Nuget|x86 = Release_Nuget|x86
+		Release_NuGet|ARM = Release_NuGet|ARM
+		Release_NuGet|x64 = Release_NuGet|x64
+		Release_NuGet|x86 = Release_NuGet|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Debug_Inbox|ARM.ActiveCfg = Debug_Inbox|ARM
@@ -48,15 +48,15 @@ Global
 		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Inbox|x86.ActiveCfg = Release_Inbox|Win32
 		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Inbox|x86.Build.0 = Release_Inbox|Win32
 		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Inbox|x86.Deploy.0 = Release_Inbox|Win32
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|ARM.ActiveCfg = Release|ARM
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|ARM.Build.0 = Release|ARM
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|ARM.Deploy.0 = Release|ARM
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x64.ActiveCfg = Release|x64
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x64.Build.0 = Release|x64
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x64.Deploy.0 = Release|x64
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x86.ActiveCfg = Release|x86
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x86.Build.0 = Release|x86
-		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_Nuget|x86.Deploy.0 = Release|x86
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|ARM.ActiveCfg = Release|ARM
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|ARM.Build.0 = Release|ARM
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|ARM.Deploy.0 = Release|ARM
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x64.ActiveCfg = Release|x64
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x64.Build.0 = Release|x64
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x64.Deploy.0 = Release|x64
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x86.ActiveCfg = Release|x86
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x86.Build.0 = Release|x86
+		{B9DB8CE5-0491-4C2D-BEF7-C25E01EF55E3}.Release_NuGet|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -134,65 +134,65 @@ jobs:
         createLogFile: true
       condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-    # - task: VSBuild@1
-    #   displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
-    #   inputs:
-    #     solution: 'Testing/**/SamplesTest.sln'
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\SamplesTest\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
+      inputs:
+        solution: 'Testing/**/SamplesTest.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\SamplesTest\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
-    # - task: VSBuild@1
-    #   displayName: 'Build MNIST-Tutorial-cs Sample'
-    #   inputs:
-    #     solution: 'Samples/MNIST/Tutorial/cs/mnist_demo.sln'
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-Tutorial\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build MNIST-Tutorial-cs Sample'
+      inputs:
+        solution: 'Samples/MNIST/Tutorial/cs/mnist_demo.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-Tutorial\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
-    # - task: VSBuild@1
-    #   displayName: 'Build MNIST-UWP-cs Sample'
-    #   inputs:
-    #     solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)_NuGet'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build MNIST-UWP-cs Sample'
+      inputs:
+        solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)_NuGet'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
-    # - task: VSBuild@1
-    #   displayName: 'Build FNSCandyStyleTransfer-UWP-CS Sample'
-    #   inputs:
-    #     solution: Samples/FNSCandyStyleTransfer/UWP/CS/snapcandy.sln
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag  /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\FNSCandyStyleTransfer\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build FNSCandyStyleTransfer-UWP-CS Sample'
+      inputs:
+        solution: Samples/FNSCandyStyleTransfer/UWP/CS/snapcandy.sln
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag  /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\FNSCandyStyleTransfer\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
-    # - task: VSBuild@1
-    #   displayName: 'Build MNIST-UWP-cppcx Sample'
-    #   inputs:
-    #     solution: 'Samples/MNIST/UWP/cppcx/mnist_cppcx.sln'
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cppcx\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build MNIST-UWP-cppcx Sample'
+      inputs:
+        solution: 'Samples/MNIST/UWP/cppcx/mnist_cppcx.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cppcx\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
     - task: CopyFiles@2
       inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -194,13 +194,14 @@ jobs:
     #     createLogFile: true
     #   condition: succeededOrFailed()
 
-    # - task: CopyFiles@2
-    #   inputs:
-    #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-    #     sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-    #     Contents: |
-    #       **\SamplesTest\**
-    #   condition: succeededOrFailed()
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+        Contents: |
+          **\SamplesTest\**
+          **\AppPackages\**
+      condition: succeededOrFailed()
 
     - task: PowerShell@2
       displayName: 'Move App Packages'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -194,13 +194,13 @@ jobs:
         createLogFile: true
       condition: succeededOrFailed()
 
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-        Contents: |
-          **\SamplesTest\**
-      condition: succeededOrFailed()
+    # - task: CopyFiles@2
+    #   inputs:
+    #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     Contents: |
+    #       **\SamplesTest\**
+    #   condition: succeededOrFailed()
 
     - task: PowerShell@2
       displayName: 'Move App Packages'

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -64,75 +64,75 @@ jobs:
       inputs:
         versionSpec: '5.11.0'
 
-    - task: PowerShell@2
-      displayName: 'Install the win 10 sdk v18362 if necessary'
-      inputs:
-        targetType: inline
-        script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
+    # - task: PowerShell@2
+    #   displayName: 'Install the win 10 sdk v18362 if necessary'
+    #   inputs:
+    #     targetType: inline
+    #     script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
 
-    - task: PowerShell@1
-      displayName: OpenCV - Configure CMake
-      inputs:
-        scriptName: external/tools/CMakeConfigureOpenCV.ps1
-        workingDirectory: $(System.ArtifactsDirectory)
-        arguments: >
-          -Architecture $(BuildPlatform)
+    # - task: PowerShell@1
+    #   displayName: OpenCV - Configure CMake
+    #   inputs:
+    #     scriptName: external/tools/CMakeConfigureOpenCV.ps1
+    #     workingDirectory: $(System.ArtifactsDirectory)
+    #     arguments: >
+    #       -Architecture $(BuildPlatform)
 
-    - task: VSBuild@1
-      displayName: 'OpenCV - Build'
-      inputs:
-        solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
-        vsVersion: "16.0"
-        msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'OpenCV - Build'
+    #   inputs:
+    #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/OpenCV.sln"'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /t:Build /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
       
-    - task: VSBuild@1
-      displayName: 'OpenCV - Install'
-      inputs:
-        solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
-        vsVersion: "16.0"
-        msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'OpenCV - Install'
+    #   inputs:
+    #     solution: 'build/external/opencv/cmake_config/$(BuildPlatform)/INSTALL.vcxproj'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '/p:Configuration=$(BuildConfiguration) /p:LinkIncremental=false /p:DebugSymbols=false /p:DebugType=None'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
-    - task: PowerShell@2
-      displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
-      inputs:
-        targetType: 'inline'
-        script: |
-          $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
-          $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
-          $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
-          nuget restore $csproj -SolutionDirectory $solution_dir
+    # - task: PowerShell@2
+    #   displayName: 'Restore WinMLSamplesGalleryNative Nuget Packages'
+    #   inputs:
+    #     targetType: 'inline'
+    #     script: |
+    #       $src_root_dir = $Env:BUILD_SOURCESDIRECTORY;
+    #       $solution_dir = [System.IO.Path]::Combine($src_root_dir, 'Samples', 'WinMLSamplesGallery')
+    #       $csproj = [System.IO.Path]::Combine($solution_dir, 'WinMLSamplesGalleryNative', 'WinMLSamplesGalleryNative.vcxproj')
+    #       nuget restore $csproj -SolutionDirectory $solution_dir
 
-    - task: VSBuild@1
-      displayName: 'Build WinMLSamplesGallery Debug'
-      inputs:
-        solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
+    # - task: VSBuild@1
+    #   displayName: 'Build WinMLSamplesGallery Debug'
+    #   inputs:
+    #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '/p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Debug'))
 
-    - task: VSBuild@1
-      displayName: 'Build And Publish WinMLSamplesGallery Release'
-      inputs:
-        solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64|arm64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+    # - task: VSBuild@1
+    #   displayName: 'Build And Publish WinMLSamplesGallery Release'
+    #   inputs:
+    #     solution: 'Samples/WinMLSamplesGallery/WinMLSamplesGallery.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '/p:UapAppxPackageBuildMode=SideloadOnly /p:AppxPackageSigningEnabled=false /p:AppxBundle=Always "/p:AppxBundlePlatforms=x86|x64|arm64" /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build,Publish'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
     - task: VSBuild@1
       displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
@@ -147,41 +147,41 @@ jobs:
         createLogFile: true
       condition: succeededOrFailed()
 
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-        Contents: |
-          **\SamplesTest\**
-          **\AppPackages\**
-      condition: succeededOrFailed()
+    # - task: CopyFiles@2
+    #   inputs:
+    #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     Contents: |
+    #       **\SamplesTest\**
+    #       **\AppPackages\**
+    #   condition: succeededOrFailed()
 
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
-        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
-        Contents: |
-          ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
-          SqueezeNetObjectDetection\*
-      condition: succeededOrFailed()
+    # - task: CopyFiles@2
+    #   inputs:
+    #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+    #     Contents: |
+    #       ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
+    #       SqueezeNetObjectDetection\*
+    #   condition: succeededOrFailed()
 
-    - task: PowerShell@2
-      displayName: 'Move App Packages'
-      inputs:
-        targetType: 'inline'
-        script: 'mv Samples/WinMLSamplesGallery/"WinMLSamplesGallery (Package)"/AppPackages $(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
-      condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
+    # - task: PowerShell@2
+    #   displayName: 'Move App Packages'
+    #   inputs:
+    #     targetType: 'inline'
+    #     script: 'mv Samples/WinMLSamplesGallery/"WinMLSamplesGallery (Package)"/AppPackages $(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
+    #   condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
-        sourceFolder: 'SharedContent'
-        contents: '**\*'
-      condition: succeededOrFailed()
+    # - task: CopyFiles@2
+    #   inputs:
+    #     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
+    #     sourceFolder: 'SharedContent'
+    #     contents: '**\*'
+    #   condition: succeededOrFailed()
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: Samples'
-      inputs:
-        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-        artifactName: WinMLPublicSamples
-      condition: succeededOrFailed()
+    # - task: PublishBuildArtifacts@1
+    #   displayName: 'Publish Artifact: Samples'
+    #   inputs:
+    #     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    #     artifactName: WinMLPublicSamples
+    #   condition: succeededOrFailed()

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -158,17 +158,17 @@ jobs:
         createLogFile: true
       condition: succeededOrFailed()
 
-    # - task: VSBuild@1
-    #   displayName: 'Build MNIST-UWP-cs Sample'
-    #   inputs:
-    #     solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
-    #     vsVersion: "16.0"
-    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-    #     platform: '$(BuildPlatform)'
-    #     configuration: '$(BuildConfiguration)_NuGet'
-    #     msbuildArchitecture: x64
-    #     createLogFile: true
-    #   condition: succeededOrFailed()
+    - task: VSBuild@1
+      displayName: 'Build MNIST-UWP-cs Sample'
+      inputs:
+        solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)_NuGet'
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
     - task: VSBuild@1
       displayName: 'Build FNSCandyStyleTransfer-UWP-CS Sample'
@@ -200,7 +200,6 @@ jobs:
         sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
         Contents: |
           **\SamplesTest\**
-          **\AppPackages\**
       condition: succeededOrFailed()
 
     - task: PowerShell@2

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -134,7 +134,18 @@ jobs:
         createLogFile: true
       condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-    # TODO: Add previously failing build tasks
+    - task: VSBuild@1
+      displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
+      inputs:
+        solution: 'Testing/**/SamplesTest.sln'
+        vsVersion: "16.0"
+        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\SamplesTest\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)'
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        clean: true
+        msbuildArchitecture: x64
+        createLogFile: true
+      condition: succeededOrFailed()
 
     - task: CopyFiles@2
       inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -203,6 +203,15 @@ jobs:
           **\AppPackages\**
       condition: succeededOrFailed()
 
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\'
+        sourceFolder: 'Samples\WinMLSamplesGallery\WinMLSamplesGallery (Package)\bin\$(BuildPlatform)\$(BuildConfiguration)\'
+        Contents: |
+          ?(AdapterSelection|CustomOperator|CustomTensorization)**\*
+          SqueezeNetObjectDetection\*
+      condition: succeededOrFailed()
+
     - task: PowerShell@2
       displayName: 'Move App Packages'
       inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -134,65 +134,65 @@ jobs:
         createLogFile: true
       condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-    - task: VSBuild@1
-      displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
-      inputs:
-        solution: 'Testing/**/SamplesTest.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\SamplesTest\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'Build UI test solution Testing/**/SamplesTest.sln'
+    #   inputs:
+    #     solution: 'Testing/**/SamplesTest.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\SamplesTest\ /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
-    - task: VSBuild@1
-      displayName: 'Build MNIST-Tutorial-cs Sample'
-      inputs:
-        solution: 'Samples/MNIST/Tutorial/cs/mnist_demo.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-Tutorial\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'Build MNIST-Tutorial-cs Sample'
+    #   inputs:
+    #     solution: 'Samples/MNIST/Tutorial/cs/mnist_demo.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-Tutorial\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
-    - task: VSBuild@1
-      displayName: 'Build MNIST-UWP-cs Sample'
-      inputs:
-        solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)_NuGet'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'Build MNIST-UWP-cs Sample'
+    #   inputs:
+    #     solution: 'Samples/MNIST/UWP/cs/mnist_demo.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cs\ /p:AppxBundle=Never /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)_NuGet'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
-    - task: VSBuild@1
-      displayName: 'Build FNSCandyStyleTransfer-UWP-CS Sample'
-      inputs:
-        solution: Samples/FNSCandyStyleTransfer/UWP/CS/snapcandy.sln
-        vsVersion: "16.0"
-        msbuildArgs: '-v:diag  /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\FNSCandyStyleTransfer\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'Build FNSCandyStyleTransfer-UWP-CS Sample'
+    #   inputs:
+    #     solution: Samples/FNSCandyStyleTransfer/UWP/CS/snapcandy.sln
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '-v:diag  /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\FNSCandyStyleTransfer\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion)  /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
-    - task: VSBuild@1
-      displayName: 'Build MNIST-UWP-cppcx Sample'
-      inputs:
-        solution: 'Samples/MNIST/UWP/cppcx/mnist_cppcx.sln'
-        vsVersion: "16.0"
-        msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cppcx\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArchitecture: x64
-        createLogFile: true
-      condition: succeededOrFailed()
+    # - task: VSBuild@1
+    #   displayName: 'Build MNIST-UWP-cppcx Sample'
+    #   inputs:
+    #     solution: 'Samples/MNIST/UWP/cppcx/mnist_cppcx.sln'
+    #     vsVersion: "16.0"
+    #     msbuildArgs: '-v:diag /p:OutDir=$(System.DefaultWorkingDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\MNIST-cppcx\ /p:AppxPackageSigningEnabled=false /p:WindowsTargetPlatformVersion=$(WindowsTargetPlatformVersion) /t:Restore,Clean,Build'
+    #     platform: '$(BuildPlatform)'
+    #     configuration: '$(BuildConfiguration)'
+    #     msbuildArchitecture: x64
+    #     createLogFile: true
+    #   condition: succeededOrFailed()
 
     # - task: CopyFiles@2
     #   inputs:


### PR DESCRIPTION
This PR adds the below samples back to the GitHub Public Samples Build and includes fixes for their previous failures
 - MNIST Tutorial CS
 - MNIST UWP CS
 - FNSCandy UWP CS
 - MNIST UWP CPP

Notable fixes include
- NuGet package upgrade from 1.5.2 to latest for the MNIST UWP CS Sample
- Changing the release configuration name in the MNIST UPW CS Sample from 'Nuget' to 'NuGet' to be consistent with the Debug release configuration name
