### PR TITLE
Fix Broken Link in Adapter Selection README

### DIFF
--- a/Samples/WinMLSamplesGallery/README.md
+++ b/Samples/WinMLSamplesGallery/README.md
@@ -42,6 +42,8 @@ To learn how to implement these features in your application, or unlock addition
 
 - [Encrypted Model](./WinMLSamplesGallery/Samples/EncryptedModel): how to use [Windows ML](https://docs.microsoft.com/en-us/windows/ai/windows-ml/) to load encrypted models from embedded resources.
 
+- [Adapter Selection](./WinMLSamplesGallery/Samples/AdapterSelection): Learn how to use [Windows ML](https://docs.microsoft.com/en-us/windows/ai/windows-ml/) with different adapters based on your power and performance needs.
+
 ## Feedback
 Please file an issue [here](https://github.com/microsoft/Windows-Machine-Learning/issues/new) if you encounter any issues with the WinML Samples Gallery or wish to request a new sample.
 

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/README.md
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/README.md
@@ -10,9 +10,9 @@ The sample showcases how to use Windows ML with different adapters that have tra
 - [External Links](#external-links)
 
 ## Getting Started
-- Check out the [source](https://github.com/microsoft/Windows-Machine-Learning/blob/master/adapter_selection/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs).
-- Learn how to [get a list of adapters using DXCore](https://github.com/microsoft/Windows-Machine-Learning/blob/master/adapter_selection/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/AdapterList.cpp#L12) to your session.
-- Learn how to [create learning model devices from adapters](https://github.com/microsoft/Windows-Machine-Learning/blob/master/adapter_selection/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/AdapterList.cpp#L41).
+- Check out the [source](https://github.com/microsoft/Windows-Machine-Learning/blob/master/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs).
+- Learn how to [get a list of adapters using DXCore](https://github.com/microsoft/Windows-Machine-Learning/blob/master/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/AdapterList.cpp#L12) to your session.
+- Learn how to [create learning model devices from adapters](https://github.com/microsoft/Windows-Machine-Learning/blob/master/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/AdapterList.cpp#L46).
 
 ## Feedback
 Please file an issue [here](https://github.com/microsoft/Windows-Machine-Learning/issues/new) if you encounter any issues with the Windows ML Samples Gallery or wish to request a new sample.


### PR DESCRIPTION
This PR
- Adds a link to the adapter selection sample from the samples gallery README
- Fixes the broken links in the adapter selection sample README