### PR TITLE
Fix broken model download links in the Samples Gallery

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
@@ -242,6 +242,9 @@ namespace WinMLSamplesGallery.Samples
             if (model != CurrentModel)
             {
                 var modelPath = _modelDictionary[model];
+                System.Diagnostics.Debug.WriteLine("Model Path");
+                System.Diagnostics.Debug.WriteLine(modelPath);
+
                 var inferenceModel = LearningModel.LoadFromFilePath(modelPath);
                 _inferenceSession = CreateLearningModelSession(inferenceModel);
 

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -165,54 +165,54 @@
 
   <Target Name="DownloadContentFiles" BeforeTargets="BeforeBuild">
     <!-- Small models. These models get shipped in the store app by default. -->
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\densenet-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/densenet-121/model/densenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\densenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/densenet-121/model/densenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\efficientnet-lite4-11.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\efficientnet-lite4-11.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\shufflenet-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/shufflenet/model/shufflenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\shufflenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/shufflenet/model/shufflenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\squeezenet1.1-7.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\squeezenet1.1-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/squeezenet/model/squeezenet1.1-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
 
     <!-- Large models. This models must be enabled for Build-From-Source scenarios -->
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\bvlcalexnet-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/alexnet/model/bvlcalexnet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\bvlcalexnet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/alexnet/model/bvlcalexnet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\caffenet-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/caffenet/model/caffenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\caffenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/caffenet/model/caffenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\googlenet-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\googlenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v2-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v2-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\mobilenetv2-7.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\mobilenetv2-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/mobilenet/model/mobilenetv2-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\rcnn-ilsvrc13-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/rcnn_ilsvrc13/model/rcnn-ilsvrc13-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\rcnn-ilsvrc13-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/rcnn_ilsvrc13/model/rcnn-ilsvrc13-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\resnet50-caffe2-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\resnet50-caffe2-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\shufflenet-v2-10.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/shufflenet/model/shufflenet-v2-10.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\shufflenet-v2-10.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/shufflenet/model/shufflenet-v2-10.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-7.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/vgg/model/vgg19-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/vgg/model/vgg19-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-bn-7.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/vgg/model/vgg19-bn-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-bn-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/vgg/model/vgg19-bn-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\zfnet512-9.onnx')" SourceUrl="https://github.com/onnx/models/raw/master/vision/classification/zfnet-512/model/zfnet512-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\zfnet512-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/zfnet-512/model/zfnet512-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
   </Target>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -165,54 +165,54 @@
 
   <Target Name="DownloadContentFiles" BeforeTargets="BeforeBuild">
     <!-- Small models. These models get shipped in the store app by default. -->
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\densenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/densenet-121/model/densenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\densenet-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/densenet-121/model/densenet-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\efficientnet-lite4-11.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\efficientnet-lite4-11.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\shufflenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/shufflenet/model/shufflenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\shufflenet-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/shufflenet/model/shufflenet-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\squeezenet1.1-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/squeezenet/model/squeezenet1.1-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\Models">
+    <DownloadFile Condition="!Exists('$(MSBuildProjectDirectory)\Models\squeezenet1.1-7.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/squeezenet/model/squeezenet1.1-7.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\Models">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
 
     <!-- Large models. This models must be enabled for Build-From-Source scenarios -->
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\bvlcalexnet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/alexnet/model/bvlcalexnet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\bvlcalexnet-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/alexnet/model/bvlcalexnet-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\caffenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/caffenet/model/caffenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\caffenet-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/caffenet/model/caffenet-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\googlenet-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\googlenet-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v2-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\inception-v2-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\mobilenetv2-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/mobilenet/model/mobilenetv2-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\mobilenetv2-7.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/mobilenet/model/mobilenetv2-7.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\rcnn-ilsvrc13-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/rcnn_ilsvrc13/model/rcnn-ilsvrc13-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\rcnn-ilsvrc13-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/rcnn_ilsvrc13/model/rcnn-ilsvrc13-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\resnet50-caffe2-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\resnet50-caffe2-v1-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/resnet/model/resnet50-caffe2-v1-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\shufflenet-v2-10.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/shufflenet/model/shufflenet-v2-10.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\shufflenet-v2-10.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/shufflenet/model/shufflenet-v2-10.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/vgg/model/vgg19-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-7.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/vgg/model/vgg19-7.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-bn-7.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/vgg/model/vgg19-bn-7.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\vgg19-bn-7.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/vgg/model/vgg19-bn-7.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\zfnet512-9.onnx')" SourceUrl="https://github.com/onnx/models/tree/main/vision/classification/zfnet-512/model/zfnet512-9.onnx" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
+    <DownloadFile Condition="$(UseLargeModels) AND !Exists('$(MSBuildProjectDirectory)\LargeModels\zfnet512-9.onnx')" SourceUrl="https://github.com/onnx/models/blob/main/vision/classification/zfnet-512/model/zfnet512-9.onnx?raw=true" DestinationFolder="$(MSBuildProjectDirectory)\LargeModels">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
   </Target>


### PR DESCRIPTION
- The links to download the models in the samples gallery were pointing to an old version of the onnx repo and were causing build issues. This PR updates the links to point to point to the correct location