### PR TITLE
Fix Github Public Samples Build Pipeline

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
@@ -126,7 +126,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -138,7 +138,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <ResourceCompile>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -219,13 +219,6 @@ jobs:
         script: 'mv Samples/WinMLSamplesGallery/"WinMLSamplesGallery (Package)"/AppPackages $(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\AppPackages'
       condition: and(succeededOrFailed(), eq(variables['BuildConfiguration'], 'Release'))
 
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)\SharedContent'
-        sourceFolder: 'SharedContent'
-        contents: '**\*'
-      condition: succeededOrFailed()
-
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: Samples'
       inputs:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -68,7 +68,7 @@ jobs:
       displayName: 'Install the win 10 sdk v18362 if necessary'
       inputs:
         targetType: inline
-        script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.18362.0\")) { choco install windows-sdk-10-version-1903-all -y }
+        script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.19041.0\")) { choco install windows-sdk-10-version-2004-all -y }
 
     - task: PowerShell@1
       displayName: OpenCV - Configure CMake

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -10,8 +10,8 @@ pool:
 
 variables:
   SamplesBin: SamplesBin
-  WINDOWS_WINMD: C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd
-  WindowsTargetPlatformVersion: 10.0.18362.0
+  WINDOWS_WINMD: C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.19041.0\Windows.winmd
+  WindowsTargetPlatformVersion: 10.0.19041.0
 
 # CI trigger
 trigger:

--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -65,10 +65,10 @@ jobs:
         versionSpec: '5.11.0'
 
     - task: PowerShell@2
-      displayName: 'Install the win 10 sdk v18362 if necessary'
+      displayName: 'Install the win 10 sdk v19041 if necessary'
       inputs:
         targetType: inline
-        script: if (-not (Test-Path "${ENV:programfiles(x86)}\windows Kits\10\include\10.0.19041.0\")) { choco install windows-sdk-10-version-2004-all -y }
+        script: choco install windows-sdk-10-version-2004-all -y
 
     - task: PowerShell@1
       displayName: OpenCV - Configure CMake


### PR DESCRIPTION
This change includes various fixes to the Github Public Samples Build Pipeline including
- Updating the pipeline to use the Windows SDK v19041 to be consistent with the gallery
- Adding the Models folder as an include directory for all configurations and platforms (this fixes the error where encrypted.onnx is not found)
- Removing the SharedContent Copy task to prevent running out of disk space