### PR TITLE
Add event trace for CPU fallback

### DIFF
--- a/Tools/WinMLRunner/WinMLRunner.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunner.vcxproj
@@ -204,7 +204,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <AdditionalDependencies>WindowsApp.lib;mincore.lib;DXGI.lib;Tdh.lib</AdditionalDependencies>
       <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"; dxgi.dll; d3d11.dll</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
@@ -233,7 +233,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <AdditionalDependencies>WindowsApp.lib;mincore.lib;DXGI.lib;Tdh.lib</AdditionalDependencies>
       <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"; dxgi.dll; d3d11.dll</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
@@ -382,7 +382,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <AdditionalDependencies>WindowsApp.lib;mincore.lib;DXGI.lib;Tdh.lib</AdditionalDependencies>
       <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"; dxgi.dll; d3d11.dll</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>
@@ -416,7 +416,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>WindowsApp.lib; mincore.lib; DXGI.lib</AdditionalDependencies>
+      <AdditionalDependencies>WindowsApp.lib;mincore.lib;DXGI.lib;Tdh.lib</AdditionalDependencies>
       <DelayLoadDLLs>"ext-ms-win-dxcore-l1-1-0.dll"; dxgi.dll; d3d11.dll</DelayLoadDLLs>
     </Link>
     <PreBuildEvent>

--- a/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj
+++ b/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj
@@ -46,6 +46,7 @@
     <ClInclude Include="src/TimerHelper.h" />
     <ClInclude Include="src/TypeHelper.h" />
     <ClInclude Include="src\LearningModelDeviceHelper.h" />
+    <ClInclude Include="src\EventTraceHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src/CommandLineArgs.cpp" />
@@ -54,6 +55,7 @@
     <ClCompile Include="src\BindingUtilities.cpp" />
     <ClCompile Include="src\LearningModelDeviceHelper.cpp" />
     <ClCompile Include="src\OutputHelper.cpp" />
+    <ClCompile Include="src\EventTraceHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -330,6 +332,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>Tdh.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_NuGet|x64'">
     <ClCompile>

--- a/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj.filters
+++ b/Tools/WinMLRunner/WinMLRunnerStaticLib.vcxproj.filters
@@ -19,6 +19,9 @@
     <ClCompile Include="src\OutputHelper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\EventTraceHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src/BindingUtilities.h">
@@ -46,6 +49,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\LearningModelDeviceHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\EventTraceHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Tools/WinMLRunner/src/CommandLineArgs.cpp
+++ b/Tools/WinMLRunner/src/CommandLineArgs.cpp
@@ -393,6 +393,10 @@ CommandLineArgs::CommandLineArgs(const std::vector<std::wstring>& args)
             }
             __debugbreak();
         }
+        else if((_wcsicmp(args[i].c_str(), L"-LogCPUFallback") == 0))
+        {
+            ToggleLogCPUFallback(true);
+        }
         else
         {
             std::wstring msg = L"Unknown option ";

--- a/Tools/WinMLRunner/src/CommandLineArgs.h
+++ b/Tools/WinMLRunner/src/CommandLineArgs.h
@@ -130,6 +130,7 @@ public:
     void ToggleEvaluationDebugOutput(bool debug) { m_evaluation_debug_output = debug; }
     void ToggleTerseOutput(bool terseOutput) { m_terseOutput = terseOutput; }
     void TogglePerfOutput(bool perfOutput) { m_perfOutput = perfOutput; }
+    void ToggleLogCPUFallback(bool logCPUFallback) { m_logCPUFallback = logCPUFallback; }
 
     void SetModelPath(const std::wstring& modelPath) { m_modelPath = modelPath; }
     void SetPerIterationDataPath(const std::wstring& perIterationDataPath)
@@ -186,6 +187,7 @@ private:
     BitmapInterpolationMode m_autoScaleInterpMode = BitmapInterpolationMode::Cubic;
     bool m_saveTensor = false;
     bool m_timeLimitIterations = false;
+    bool m_logCPUFallback = false;
     std::wstring m_saveTensorMode = L"First";
     ::TensorizeArgs m_tensorizeArgs;
 

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -202,7 +202,7 @@ static DWORD GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo)
     return status;
 }
 
-static std::wstring& TrimOperatorName(std::wstring& s)
+static std::wstring TrimOperatorName(std::wstring& s)
 {
     wstring substring = L"_kernel_time";
     int offset = (int)s.find(substring);

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -1,5 +1,5 @@
-#include "EventTraceHelper.h"
 #include <direct.h>
+#include "EventTraceHelper.h"
 
 #define LOGSESSION_NAME L"winml"
 

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -24,7 +24,7 @@ Level Verbosity is as follows:
 From <https://docs.microsoft.com/en-us/message-analyzer/system-etw-provider-event-keyword-level-settings>  
 */
 
-void EventTraceHelper::RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo)
+static void RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo)
 {
     DWORD byteLength = 0;
 
@@ -35,7 +35,7 @@ void EventTraceHelper::RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo)
     }
 }
 
-DWORD EventTraceHelper::GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT ArraySize)
+static DWORD GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT ArraySize)
 {
     DWORD status = ERROR_SUCCESS;
     PROPERTY_DATA_DESCRIPTOR dataDescriptor;
@@ -64,7 +64,7 @@ DWORD EventTraceHelper::GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pIn
 // map values can be integer values or bit values. If the property specifies a value
 // map, get the map.
 
-DWORD EventTraceHelper::GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD DecodingSource,
+static DWORD GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD DecodingSource,
                                    PEVENT_MAP_INFO& pMapInfo)
 {
     DWORD status = ERROR_SUCCESS;
@@ -111,7 +111,7 @@ DWORD EventTraceHelper::GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD 
     return status;
 }
 
-DWORD EventTraceHelper::GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT PropertyLength)
+static DWORD GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT PropertyLength)
 {
     DWORD status = ERROR_SUCCESS;
     PROPERTY_DATA_DESCRIPTOR dataDescriptor;
@@ -170,7 +170,7 @@ DWORD EventTraceHelper::GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INF
     return status;
 }
 
-DWORD EventTraceHelper::GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo)
+static DWORD GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo)
 {
     DWORD status = ERROR_SUCCESS;
     DWORD bufferSize = 0;
@@ -202,7 +202,7 @@ DWORD EventTraceHelper::GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_I
     return status;
 }
 
-std::wstring& EventTraceHelper::TrimOperatorName(std::wstring& s)
+static std::wstring& TrimOperatorName(std::wstring& s)
 {
     wstring substring = L"_kernel_time";
     int offset = (int)s.find(substring);
@@ -232,7 +232,7 @@ std::wstring& EventTraceHelper::TrimOperatorName(std::wstring& s)
 /// \return A DWORD with a windows error value. If the function succeded, it returns
 ///     ERROR_SUCCESS.
 ///
-DWORD EventTraceHelper::GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRecord,
+static DWORD GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRecord,
                                               _In_ const PTRACE_EVENT_INFO EventInfo,
                               _In_ USHORT Index, _Inout_ PBYTE& UserData, _In_ PBYTE EndOfUserData,
                               _Inout_ wstring& propertyValue)
@@ -353,7 +353,7 @@ DWORD EventTraceHelper::GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRe
 /// \return A DWORD with a windows error value. If the function succeded, it returns
 ///     ERROR_SUCCESS.
 ///
-DWORD EventTraceHelper::FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord,
+static DWORD FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord,
                                                _In_ const PTRACE_EVENT_INFO EventInfo)
 {
     DWORD status = ERROR_SUCCESS;
@@ -419,7 +419,7 @@ DWORD EventTraceHelper::FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventR
     return ERROR_SUCCESS;
 }
 
-VOID WINAPI EventTraceHelper::EventRecordCallback(EVENT_RECORD* pEventRecord)
+static VOID WINAPI EventRecordCallback(EVENT_RECORD* pEventRecord)
 {
     // This is where you would get the details of ETW event
     DWORD status = ERROR_SUCCESS;
@@ -470,7 +470,7 @@ VOID WINAPI EventTraceHelper::EventRecordCallback(EVENT_RECORD* pEventRecord)
     }
 }
 
-ULONG WINAPI EventTraceHelper::BufferCallback(PEVENT_TRACE_LOGFILEW pLogFile) 
+static ULONG WINAPI BufferCallback(PEVENT_TRACE_LOGFILEW pLogFile) 
 { 
     return TRUE; 
 }

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -1,0 +1,559 @@
+#include "EventTraceHelper.h"
+#include <direct.h>
+
+#define LOGSESSION_NAME _T("winml")
+
+struct __declspec(uuid("{BCAD6AEE-C08D-4F66-828C-4C43461A033D}")) DXGKRNL_PROVIDER_GUID_HOLDER;
+
+static const auto DXGKRNL_PROVIDER_GUID = __uuidof(DXGKRNL_PROVIDER_GUID_HOLDER);
+
+DWORD EventTraceHelper::PointerSize = 0;
+CommandLineArgs EventTraceHelper::commandArgs;
+
+    /*logman update trace winml -p {BCAD6AEE-C08D-4F66-828C-4C43461A033D} <keyword> <level verbosity> -ets 
+To capture only WinML Traces replace <keyword> with 0x1 
+To capture only Lotus Profiling Traces replace <keyword> with 0x2 
+	Bit 0: WinML Traces 
+	Bit 1: Graph profiler 
+Level Verbosity is as follows: 
+	- (0x0) LogAlways 
+	- (0x1) Critical 
+	- (0x2) Error 
+	- (0x3) Warning 
+	- (0x4) Information
+	- (0x5) Verbose 
+From <https://docs.microsoft.com/en-us/message-analyzer/system-etw-provider-event-keyword-level-settings>  
+*/
+
+void EventTraceHelper::RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo)
+{
+    DWORD byteLength = 0;
+
+    for (DWORD i = 0; i < pMapInfo->EntryCount; i++)
+    {
+        byteLength = (wcslen((LPWSTR)((PBYTE)pMapInfo + pMapInfo->MapEntryArray[i].OutputOffset)) - 1) * 2;
+        *((LPWSTR)((PBYTE)pMapInfo + (pMapInfo->MapEntryArray[i].OutputOffset + byteLength))) = L'\0';
+    }
+}
+
+DWORD EventTraceHelper::GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT ArraySize)
+{
+    DWORD status = ERROR_SUCCESS;
+    PROPERTY_DATA_DESCRIPTOR dataDescriptor;
+    DWORD propertySize = 0;
+
+    if ((pInfo->EventPropertyInfoArray[i].Flags & PropertyParamCount) == PropertyParamCount)
+    {
+        DWORD Count = 0; // Expects the count to be defined by a UINT16 or UINT32
+        DWORD j = pInfo->EventPropertyInfoArray[i].countPropertyIndex;
+        ZeroMemory(&dataDescriptor, sizeof(PROPERTY_DATA_DESCRIPTOR));
+        dataDescriptor.PropertyName = (ULONGLONG)((PBYTE)(pInfo) + pInfo->EventPropertyInfoArray[j].NameOffset);
+        dataDescriptor.ArrayIndex = ULONG_MAX;
+        status = TdhGetPropertySize(pEvent, 0, NULL, 1, &dataDescriptor, &propertySize);
+        status = TdhGetProperty(pEvent, 0, NULL, 1, &dataDescriptor, propertySize, (PBYTE)&Count);
+        *ArraySize = (USHORT)Count;
+    }
+    else
+    {
+        *ArraySize = pInfo->EventPropertyInfoArray[i].count;
+    }
+
+    return status;
+}
+
+// Both MOF-based events and manifest-based events can specify name/value maps. The
+// map values can be integer values or bit values. If the property specifies a value
+// map, get the map.
+
+DWORD EventTraceHelper::GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD DecodingSource,
+                                   PEVENT_MAP_INFO& pMapInfo)
+{
+    DWORD status = ERROR_SUCCESS;
+    DWORD mapSize = 0;
+
+    // Retrieve the required buffer size for the map info.
+
+    status = TdhGetEventMapInformation(pEvent, pMapName, pMapInfo, &mapSize);
+
+    if (ERROR_INSUFFICIENT_BUFFER == status)
+    {
+        pMapInfo = (PEVENT_MAP_INFO)malloc(mapSize);
+        if (pMapInfo == NULL)
+        {
+            printf("Failed to allocate memory for map info (size=%lu).\n", mapSize);
+            status = ERROR_OUTOFMEMORY;
+            return status;
+        }
+
+        // Retrieve the map info.
+
+        status = TdhGetEventMapInformation(pEvent, pMapName, pMapInfo, &mapSize);
+    }
+
+    if (ERROR_SUCCESS == status)
+    {
+        if (DecodingSourceXMLFile == DecodingSource)
+        {
+            RemoveTrailingSpace(pMapInfo);
+        }
+    }
+    else
+    {
+        if (ERROR_NOT_FOUND == status)
+        {
+            status = ERROR_SUCCESS; // This case is okay.
+        }
+        else
+        {
+            printf("TdhGetEventMapInformation failed with 0x%x.\n", status);
+        }
+    }
+
+    return status;
+}
+
+DWORD EventTraceHelper::GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT PropertyLength)
+{
+    DWORD status = ERROR_SUCCESS;
+    PROPERTY_DATA_DESCRIPTOR dataDescriptor;
+    DWORD propertySize = 0;
+
+    // If the property is a binary blob and is defined in a manifest, the property can
+    // specify the blob's size or it can point to another property that defines the
+    // blob's size. The PropertyParamLength flag tells you where the blob's size is defined.
+
+    if ((pInfo->EventPropertyInfoArray[i].Flags & PropertyParamLength) == PropertyParamLength)
+    {
+        DWORD Length = 0; // Expects the length to be defined by a UINT16 or UINT32
+        DWORD j = pInfo->EventPropertyInfoArray[i].lengthPropertyIndex;
+        ZeroMemory(&dataDescriptor, sizeof(PROPERTY_DATA_DESCRIPTOR));
+        dataDescriptor.PropertyName = (ULONGLONG)((PBYTE)(pInfo) + pInfo->EventPropertyInfoArray[j].NameOffset);
+        dataDescriptor.ArrayIndex = ULONG_MAX;
+        status = TdhGetPropertySize(pEvent, 0, NULL, 1, &dataDescriptor, &propertySize);
+        status = TdhGetProperty(pEvent, 0, NULL, 1, &dataDescriptor, propertySize, (PBYTE)&Length);
+        *PropertyLength = (USHORT)Length;
+    }
+    else
+    {
+        if (pInfo->EventPropertyInfoArray[i].length > 0)
+        {
+            *PropertyLength = pInfo->EventPropertyInfoArray[i].length;
+        }
+        else
+        {
+            // If the property is a binary blob and is defined in a MOF class, the extension
+            // qualifier is used to determine the size of the blob. However, if the extension
+            // is IPAddrV6, you must set the PropertyLength variable yourself because the
+            // EVENT_PROPERTY_INFO.length field will be zero.
+
+            if (TDH_INTYPE_BINARY == pInfo->EventPropertyInfoArray[i].nonStructType.InType &&
+                TDH_OUTTYPE_IPV6 == pInfo->EventPropertyInfoArray[i].nonStructType.OutType)
+            {
+                *PropertyLength = (USHORT)sizeof(IN6_ADDR);
+            }
+            else if (TDH_INTYPE_UNICODESTRING == pInfo->EventPropertyInfoArray[i].nonStructType.InType ||
+                     TDH_INTYPE_ANSISTRING == pInfo->EventPropertyInfoArray[i].nonStructType.InType ||
+                     (pInfo->EventPropertyInfoArray[i].Flags & PropertyStruct) == PropertyStruct)
+            {
+                *PropertyLength = pInfo->EventPropertyInfoArray[i].length;
+            }
+            else
+            {
+                printf("Unexpected length of 0 for intype %d and outtype %d\n",
+                        pInfo->EventPropertyInfoArray[i].nonStructType.InType,
+                        pInfo->EventPropertyInfoArray[i].nonStructType.OutType);
+
+                status = ERROR_EVT_INVALID_EVENT_DATA;
+            }
+        }
+    }
+
+    return status;
+}
+
+DWORD EventTraceHelper::GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo)
+{
+    DWORD status = ERROR_SUCCESS;
+    DWORD bufferSize = 0;
+
+    // Retrieve the required buffer size for the event metadata.
+
+    status = TdhGetEventInformation(pEvent, 0, NULL, pInfo, &bufferSize);
+
+    if (ERROR_INSUFFICIENT_BUFFER == status)
+    {
+        pInfo = (TRACE_EVENT_INFO*)malloc(bufferSize);
+        if (pInfo == NULL)
+        {
+            printf("Failed to allocate memory for event info (size=%lu).\n", bufferSize);
+            status = ERROR_OUTOFMEMORY;
+            return status;
+        }
+
+        // Retrieve the event metadata.
+
+        status = TdhGetEventInformation(pEvent, 0, NULL, pInfo, &bufferSize);
+    }
+
+    if (ERROR_SUCCESS != status)
+    {
+        printf("TdhGetEventInformation failed with 0x%x.\n", status);
+    }
+
+    return status;
+}
+
+std::wstring& EventTraceHelper::TrimOperatorName(std::wstring& s)
+{
+    wstring substring = L"_kernel_time";
+    int offset = (int)s.find(substring);
+    if (offset != -1)
+    {
+        s.erase(offset, substring.length());
+        substring = L"_nchwc";
+        offset = (int)s.find(substring);
+        if (offset != -1)
+        {
+            s.erase(offset, substring.length());
+        }
+    }
+    return s;
+}
+
+///
+/// Return formated property data
+///
+/// \param EventRecord      The event record received by EventRecordCallback
+/// \param EventInfo        A struct with event metadata.
+/// \param Index            The index of the property to read.
+/// \param pStructureName   Used to retrieve the property if it is inside a struct.
+/// \param StructIndex      Used to retrieve the property if it is inside a struct.
+/// \param Result           A wide string stream, where the formatted values are appended.
+///
+/// \return A DWORD with a windows error value. If the function succeded, it returns
+///     ERROR_SUCCESS.
+///
+DWORD EventTraceHelper::GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRecord,
+                                              _In_ const PTRACE_EVENT_INFO EventInfo,
+                              _In_ USHORT Index, _Inout_ PBYTE& UserData, _In_ PBYTE EndOfUserData,
+                              _Inout_ wstring& propertyValue)
+{
+    DWORD status = ERROR_SUCCESS;
+    DWORD lastMember = 0; // Last member of a structure
+    USHORT propertyLength = 0;
+    USHORT arraySize = 0;
+    DWORD formattedDataSize = 0;
+    std::vector<BYTE> formattedData;
+    USHORT userDataConsumed = 0;
+
+    status = GetPropertyLength(EventRecord, EventInfo, Index, &propertyLength);
+    if (ERROR_SUCCESS != status)
+    {
+        printf("Failed to query ETW event propery length. Error: %ul", status);
+        UserData = NULL;
+
+        return status;
+    }
+
+    //
+    // Get the size of the array if the property is an array.
+    //
+    status = GetArraySize(EventRecord, EventInfo, Index, &arraySize);
+
+    for (USHORT k = 0; k < arraySize; k++)
+    {
+        //
+        // If the property is a structure, skip.
+        //
+        if ((EventInfo->EventPropertyInfoArray[Index].Flags & PropertyStruct) == PropertyStruct)
+        {
+            continue;
+        }
+        else if (propertyLength > 0 || (EndOfUserData - UserData) > 0)
+        {
+            PEVENT_MAP_INFO pMapInfo = NULL;
+
+            //
+            // If the property could be a map, try to get its info.
+            //
+            if (TDH_INTYPE_UINT32 == EventInfo->EventPropertyInfoArray[Index].nonStructType.InType &&
+                EventInfo->EventPropertyInfoArray[Index].nonStructType.MapNameOffset != 0)
+            {
+                status = GetMapInfo(
+                    EventRecord,
+                    (PWCHAR)((PBYTE)(EventInfo) + EventInfo->EventPropertyInfoArray[Index].nonStructType.MapNameOffset),
+                    EventInfo->DecodingSource, pMapInfo);
+
+                if (ERROR_SUCCESS != status)
+                {
+                    printf("Failed to query ETW event property of type map. Error: %lu", status);
+
+                    if (pMapInfo)
+                    {
+                        free(pMapInfo);
+                        pMapInfo = NULL;
+                    }
+
+                    break;
+                }
+            }
+
+            //
+            // Get the size of the buffer required for the formatted data.
+            //
+            status = TdhFormatProperty(EventInfo, pMapInfo, PointerSize,
+                                       EventInfo->EventPropertyInfoArray[Index].nonStructType.InType,
+                                       EventInfo->EventPropertyInfoArray[Index].nonStructType.OutType, propertyLength,
+                                       (USHORT)(EndOfUserData - UserData), UserData, &formattedDataSize,
+                                       (PWCHAR)formattedData.data(), &userDataConsumed);
+
+            if (ERROR_INSUFFICIENT_BUFFER == status)
+            {
+                formattedData.resize(formattedDataSize);
+
+                //
+                // Retrieve the formatted data.
+                //
+                status = TdhFormatProperty(EventInfo, pMapInfo, PointerSize,
+                                           EventInfo->EventPropertyInfoArray[Index].nonStructType.InType,
+                                           EventInfo->EventPropertyInfoArray[Index].nonStructType.OutType,
+                                           propertyLength, (USHORT)(EndOfUserData - UserData), UserData,
+                                           &formattedDataSize, (PWCHAR)formattedData.data(), &userDataConsumed);
+            }
+
+            if (pMapInfo)
+            {
+                free(pMapInfo);
+                pMapInfo = NULL;
+            }
+
+            if (ERROR_SUCCESS == status)
+            {
+                propertyValue.assign((PWCHAR)formattedData.data());
+                UserData += userDataConsumed;
+            }
+            else
+            {
+                printf("Failed to format ETW event property value. Error: %lu", status);
+                UserData = NULL;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+///
+/// Formats the data of an event while searching for CPU fallback related events
+///
+/// \param EventRecord  The event record received by EventRecordCallback
+/// \param EventInfo    A struct with event metadata.
+/// \param Result       A string with the formatted data.
+///
+/// \return A DWORD with a windows error value. If the function succeded, it returns
+///     ERROR_SUCCESS.
+///
+DWORD EventTraceHelper::FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord,
+                                               _In_ const PTRACE_EVENT_INFO EventInfo)
+{
+    DWORD status = ERROR_SUCCESS;
+
+    if (EVENT_HEADER_FLAG_32_BIT_HEADER == (EventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_32_BIT_HEADER))
+    {
+        PointerSize = 4;
+    }
+    else
+    {
+        PointerSize = 8;
+    }
+
+    if (EVENT_HEADER_FLAG_STRING_ONLY == (EventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_STRING_ONLY))
+    {
+        // Do nothing
+    }
+    else
+    {
+        PBYTE pUserData = (PBYTE)EventRecord->UserData;
+        PBYTE pEndOfUserData = (PBYTE)EventRecord->UserData + EventRecord->UserDataLength;
+        PWCHAR pPropertyName;
+        wstring operatorType;
+        wstring operatorName;
+        wstring duration;
+        wstring propertyValue;
+        wstring executionProvider;
+        for (USHORT i = 0; i < EventInfo->TopLevelPropertyCount; i++)
+        {
+            pPropertyName = (PWCHAR)((PBYTE)(EventInfo) + EventInfo->EventPropertyInfoArray[i].NameOffset);
+            status = GetFormatedPropertyData(EventRecord, EventInfo, i, pUserData, pEndOfUserData, propertyValue);
+            if (wcscmp(pPropertyName, L"Operator Name") == 0)
+            {
+                operatorType = propertyValue;
+            }
+            else if (wcscmp(pPropertyName, L"Event Name") == 0)
+            {
+                operatorName = TrimOperatorName(propertyValue);
+            }
+            else if (wcscmp(pPropertyName, L"Duration (us)") == 0)
+            {
+                duration = propertyValue;
+            }
+            else if (wcscmp(pPropertyName, L"Execution Provider") == 0)
+            {
+                executionProvider = propertyValue;
+            }
+            if (ERROR_SUCCESS != status)
+            {
+                printf("Failed to format ETW event user data..");
+
+                return status;
+            }
+        }
+        if (commandArgs.UseGPU() && 
+            wcscmp(executionProvider.c_str(), L"CPUExecutionProvider") == 0 && 
+            !operatorName.empty())
+        {
+            wprintf(L"WARNING: CPU fallback detected for operator %s(%s), duration: %s\n", operatorName.c_str(),
+                    operatorType.c_str(), duration.c_str());
+        }
+    }
+
+    return ERROR_SUCCESS;
+}
+
+VOID WINAPI EventTraceHelper::EventRecordCallback(EVENT_RECORD* pEventRecord)
+{
+    // This is where you would get the details of ETW event
+    DWORD status = ERROR_SUCCESS;
+    PTRACE_EVENT_INFO pInfo = NULL;
+    LPWSTR pwsEventGuid = NULL;
+    PBYTE pUserData = NULL;
+    PBYTE pEndOfUserData = NULL;
+    ULONGLONG TimeStamp = 0;
+    ULONGLONG Nanoseconds = 0;
+
+    // Skips the event if it is the event trace header. Log files contain this event
+    // but real-time sessions do not. The event contains the same information as
+    // the EVENT_TRACE_LOGFILE.LogfileHeader member that you can access when you open
+    // the trace.
+
+    if (IsEqualGUID(pEventRecord->EventHeader.ProviderId, EventTraceGuid) &&
+        pEventRecord->EventHeader.EventDescriptor.Opcode == EVENT_TRACE_TYPE_INFO)
+    {
+        // Skip this event.
+    }
+    else
+    {
+        // Process the event. The pEventRecord->UserData member is a pointer to
+        // the event specific data, if it exists.
+
+        status = GetEventInformation(pEventRecord, pInfo);
+
+        if (ERROR_SUCCESS != status)
+        {
+            printf("GetEventInformation failed with %lu\n", status);
+            goto cleanup;
+        }
+
+        if (DecodingSourceTlg == pInfo->DecodingSource)
+        {
+            FormatDataForCPUFallback(pEventRecord, pInfo);
+        }
+        else // Not handling any events other than Tlg type
+        {
+            // Do nothing
+        }
+    }
+
+cleanup:
+
+    if (pInfo)
+    {
+        free(pInfo);
+    }
+}
+
+ULONG WINAPI EventTraceHelper::BufferCallback(PEVENT_TRACE_LOGFILEW pLogFile) 
+{ 
+    return TRUE; 
+}
+
+void EventTraceHelper::ProcessEventTrace(PTRACEHANDLE traceHandle)
+{
+    try
+    {
+        auto status = ProcessTrace(
+            traceHandle, 1, 0,
+            0); // this call blocks until either the session is stopped or an exception is occurred in event_callback
+        if (status != ERROR_SUCCESS && status != ERROR_CANCELLED)
+        {
+            printf("ProcessTrace failed with %lu\n", status);
+        }
+    }
+    catch (exception ex)
+    {
+        printf("Exception when processing event trace: %s\n", ex.what());
+        // catch exceptions occurred in event_callback
+    }
+}
+
+void EventTraceHelper::Start()
+{
+    int bufferSize = sizeof(EVENT_TRACE_PROPERTIES) + (sizeof(LOGSESSION_NAME) + 1) * sizeof(wchar_t);
+    sessionProperties = static_cast<PEVENT_TRACE_PROPERTIES>(malloc(bufferSize));
+    ZeroMemory(sessionProperties, bufferSize);
+
+    GUID guid;
+    UuidCreate(&guid);
+    sessionProperties->Wnode.BufferSize = static_cast<ULONG>(bufferSize);
+    sessionProperties->Wnode.Guid = guid;
+    sessionProperties->Wnode.ClientContext = 0;
+    sessionProperties->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    sessionProperties->LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+    sessionProperties->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+
+    auto hr = StartTrace(static_cast<PTRACEHANDLE>(&sessionHandle), LOGSESSION_NAME, sessionProperties);
+    if (hr != ERROR_SUCCESS)
+    {
+        printf("Error starting event trace: Trace already started %s\n", GetLastError());
+    }
+    auto status = EnableTraceEx2(sessionHandle, &DXGKRNL_PROVIDER_GUID, EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+                                 TRACE_LEVEL_VERBOSE, 2, 0, 0, nullptr);
+
+    EVENT_TRACE_LOGFILE loggerInfo = {};
+
+    TRACE_LOGFILE_HEADER* pHeader = &loggerInfo.LogfileHeader;
+    ZeroMemory(&loggerInfo, sizeof(EVENT_TRACE_LOGFILE));
+    loggerInfo.LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+    loggerInfo.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_RAW_TIMESTAMP | PROCESS_TRACE_MODE_EVENT_RECORD;
+    loggerInfo.BufferCallback = BufferCallback;
+
+    // provide a callback whenever we get an event record
+    loggerInfo.EventRecordCallback = EventRecordCallback;
+    loggerInfo.Context = nullptr;
+    // LoggerName is the sessionName that we had provided in StartTrace
+    // For consuming events from ETL file we will provide path to ETL file.
+
+    loggerInfo.LoggerName = const_cast<LPWSTR>(LOGSESSION_NAME);
+
+    traceHandle = OpenTrace(&loggerInfo);
+    if (traceHandle == INVALID_PROCESSTRACE_HANDLE)
+    {
+        printf("Error opening event trace: OpenTrace failed with %lu\n", GetLastError());
+        throw std::runtime_error("Unable to open trace");
+    }
+
+    if (pHeader->PointerSize != sizeof(PVOID))
+        pHeader = (PTRACE_LOGFILE_HEADER)((PUCHAR)pHeader + 2 * (pHeader->PointerSize - sizeof(PVOID)));
+
+    PTRACEHANDLE pt = static_cast<PTRACEHANDLE>(&traceHandle);
+    threadPool.SubmitWork(ProcessEventTrace, pt);
+}
+
+void EventTraceHelper::Stop()
+{
+    auto status = CloseTrace(traceHandle);
+    status = ControlTrace(sessionHandle, nullptr, sessionProperties, EVENT_TRACE_CONTROL_STOP);
+    status = EnableTraceEx2(sessionHandle, &DXGKRNL_PROVIDER_GUID, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, nullptr);
+}
+

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -500,6 +500,9 @@ void EventTraceHelper::Start()
     {
         return;
     }
+
+    // Please refer to this link to understand why buffersize was setup in such a seemingly random manner:
+    // https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_propertiesbuffersize
     int bufferSize = sizeof(EVENT_TRACE_PROPERTIES) + (sizeof(LOGSESSION_NAME) + 1) * sizeof(wchar_t);
     m_sessionProperties = static_cast<PEVENT_TRACE_PROPERTIES>(malloc(bufferSize));
     ZeroMemory(m_sessionProperties, bufferSize);

--- a/Tools/WinMLRunner/src/EventTraceHelper.h
+++ b/Tools/WinMLRunner/src/EventTraceHelper.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <iostream>
-#include <windows.h>
-#include <evntrace.h>
+#include "CommandLineArgs.h"
 #include <evntcons.h>
+#include <evntrace.h>
+#include <in6addr.h>
+#include <iostream>
 #include <tchar.h>
 #include <tdh.h>
 #include "ThreadPool.h"
-#include <in6addr.h>
-#include "CommandLineArgs.h"
+#include <windows.h>
 
 using namespace std;
 

--- a/Tools/WinMLRunner/src/EventTraceHelper.h
+++ b/Tools/WinMLRunner/src/EventTraceHelper.h
@@ -31,18 +31,5 @@ public:
 
 private:
     static void ProcessEventTrace(PTRACEHANDLE traceHandle);
-    static ULONG WINAPI BufferCallback(PEVENT_TRACE_LOGFILEW pLogFile);
-    static VOID WINAPI EventRecordCallback(EVENT_RECORD* pEventRecord);
-    
-    static void RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo);
-    static DWORD GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT ArraySize);
-    static DWORD GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD DecodingSource, PEVENT_MAP_INFO& pMapInfo);
-    static DWORD GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT PropertyLength);
-    static DWORD GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo);
-    static wstring& TrimOperatorName(wstring& s);
-    static DWORD GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRecord, _In_ const PTRACE_EVENT_INFO EventInfo,
-                                         _In_ USHORT Index, _Inout_ PBYTE& UserData, _In_ PBYTE EndOfUserData,
-                                         _Inout_ wstring& propertyValue);
-    static DWORD FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord, _In_ const PTRACE_EVENT_INFO EventInfo);
 
 };

--- a/Tools/WinMLRunner/src/EventTraceHelper.h
+++ b/Tools/WinMLRunner/src/EventTraceHelper.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <iostream>
+#include <windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <tchar.h>
+#include <tdh.h>
+#include "ThreadPool.h"
+#include <in6addr.h>
+#include "CommandLineArgs.h"
+
+using namespace std;
+
+class EventTraceHelper
+{
+private:
+    TRACEHANDLE traceHandle;
+    TRACEHANDLE sessionHandle;
+    PEVENT_TRACE_PROPERTIES sessionProperties;
+    ThreadPool threadPool;
+    static DWORD PointerSize;
+    static CommandLineArgs commandArgs;
+
+public:
+    EventTraceHelper(CommandLineArgs args) : sessionHandle(INVALID_PROCESSTRACE_HANDLE), threadPool(1)
+    {
+        commandArgs = args;
+    }
+
+    void Start();
+    void Stop();
+
+private:
+    static void ProcessEventTrace(PTRACEHANDLE traceHandle);
+    static ULONG WINAPI BufferCallback(PEVENT_TRACE_LOGFILEW pLogFile);
+    static VOID WINAPI EventRecordCallback(EVENT_RECORD* pEventRecord);
+    
+    static void RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo);
+    static DWORD GetArraySize(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT ArraySize);
+    static DWORD GetMapInfo(PEVENT_RECORD pEvent, LPWSTR pMapName, DWORD DecodingSource, PEVENT_MAP_INFO& pMapInfo);
+    static DWORD GetPropertyLength(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO pInfo, USHORT i, PUSHORT PropertyLength);
+    static DWORD GetEventInformation(PEVENT_RECORD pEvent, PTRACE_EVENT_INFO& pInfo);
+    static wstring& TrimOperatorName(wstring& s);
+    static DWORD GetFormatedPropertyData(_In_ const PEVENT_RECORD EventRecord, _In_ const PTRACE_EVENT_INFO EventInfo,
+                                         _In_ USHORT Index, _Inout_ PBYTE& UserData, _In_ PBYTE EndOfUserData,
+                                         _Inout_ wstring& propertyValue);
+    static DWORD FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord, _In_ const PTRACE_EVENT_INFO EventInfo);
+
+};

--- a/Tools/WinMLRunner/src/EventTraceHelper.h
+++ b/Tools/WinMLRunner/src/EventTraceHelper.h
@@ -14,15 +14,14 @@ using namespace std;
 class EventTraceHelper
 {
 private:
-    TRACEHANDLE traceHandle;
-    TRACEHANDLE sessionHandle;
-    PEVENT_TRACE_PROPERTIES sessionProperties;
-    ThreadPool threadPool;
-    static DWORD PointerSize;
-    static CommandLineArgs commandArgs;
+    TRACEHANDLE m_traceHandle;
+    TRACEHANDLE m_sessionHandle;
+    PEVENT_TRACE_PROPERTIES m_sessionProperties;
+    ThreadPool m_threadPool;
+    CommandLineArgs commandArgs;
 
 public:
-    EventTraceHelper(CommandLineArgs args) : sessionHandle(INVALID_PROCESSTRACE_HANDLE), threadPool(1)
+    EventTraceHelper(CommandLineArgs args) : m_sessionHandle(INVALID_PROCESSTRACE_HANDLE), m_threadPool(1)
     {
         commandArgs = args;
     }

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -561,6 +561,7 @@ int run(CommandLineArgs& args,
         if (args.IsConcurrentLoad())
         {
             ConcurrentLoadModel(modelPaths, args.NumThreads(), args.ThreadInterval(), true);
+            printf("Concurrent model loading, will skip event trace for CPU fallback.");
             return 0;
         }
         traceHelper.Start();

--- a/Tools/WinMLRunner/src/Run.cpp
+++ b/Tools/WinMLRunner/src/Run.cpp
@@ -2,6 +2,7 @@
 #include "Common.h"
 #include "OutputHelper.h"
 #include "BindingUtilities.h"
+#include "EventTraceHelper.h"
 #include <filesystem>
 #include <d3d11.h>
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
@@ -529,6 +530,7 @@ int run(CommandLineArgs& args,
         const std::vector<LearningModelDeviceWithMetadata>& deviceList,
         const LearningModelSessionOptions& sessionOptions) try
 {
+    EventTraceHelper traceHelper(args);
     // Initialize COM in a multi-threaded environment.
     winrt::init_apartment();
     OutputHelper output(args.NumIterations());
@@ -561,6 +563,7 @@ int run(CommandLineArgs& args,
             ConcurrentLoadModel(modelPaths, args.NumThreads(), args.ThreadInterval(), true);
             return 0;
         }
+        traceHelper.Start();
         for (const auto& path : modelPaths)
         {
             LearningModel model = nullptr;
@@ -619,6 +622,7 @@ int run(CommandLineArgs& args,
                 }
             }
         }
+        traceHelper.Stop();
         return lastHr;
     }
     return 0;


### PR DESCRIPTION
Add event trace for CPU fallback.

The output warnings for fall back include op name, op type and duration in us

![image](https://user-images.githubusercontent.com/19560213/163490557-92630898-4cd2-45d4-8d76-3c37e60f091b.png)
