### PR TITLE
Fixed blocking issue caused by Python version incompatibility with get-pip.py.

### DIFF
--- a/Tools/WinMLDashboard/src/native/python.tsx
+++ b/Tools/WinMLDashboard/src/native/python.tsx
@@ -114,7 +114,7 @@ export async function downloadPip(listener?: IOutputListener) {
     return new Promise(async (resolve, reject) => {
         const installer = path.join(localPython, 'get-pip.py');
         try {
-            const data = await downloadBinaryFile('https://bootstrap.pypa.io/get-pip.py') as Buffer;
+            const data = await downloadBinaryFile('https://bootstrap.pypa.io/pip/3.6/get-pip.py') as Buffer;
             fs.writeFileSync(installer, data);
             await python([installer], {}, listener);
         } catch (err) {


### PR DESCRIPTION
Fixed blocking issue caused by incompatibility with get-pip.py and Python 3.6. Automation now retrieves archived 3.6 compatible version of get-pip.py.