### PR TITLE
Set Model Names in Samples for Telemetry

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
@@ -132,7 +132,7 @@
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.1" />
+    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.11.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-stable" />
   </ItemGroup>
 </Project>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Pages/SampleBasePage.xaml.cs
@@ -1,6 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using Microsoft.AI.MachineLearning;
+using Microsoft.AI.MachineLearning.Experimental;
 using System;
 
 namespace WinMLSamplesGallery
@@ -55,6 +57,13 @@ namespace WinMLSamplesGallery
                 var page = (Samples.Batching)SampleFrame.Content;
                 page.StopAllEvents();
             }
+        }
+
+        public static void SetModelNameForTelemetry(String modelName, String sampleName, LearningModel model)
+        {
+            var telemetryModelName = modelName + "_" + sampleName;
+            var experimentalModel = new LearningModelExperimental(model);
+            experimentalModel.SetName(telemetryModelName);
         }
     }
 }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs
@@ -34,6 +34,7 @@ namespace WinMLSamplesGallery.Samples
             adapter_options.AddRange(adapters);
             AdapterListView.ItemsSource = adapter_options;
 
+            // Run in background thread to avoid blocking UI on sample launch
             Task.Run(() => SetModelNameForTelemetry(device));
         }
 
@@ -103,6 +104,7 @@ namespace WinMLSamplesGallery.Samples
             return adapters;
         }
 
+        // Session must be created for telemety to be sent
         private void SetModelNameForTelemetry(LearningModelDevice device)
         {
             var modelName = "squeezenet1.1-7.onnx";
@@ -110,7 +112,7 @@ namespace WinMLSamplesGallery.Samples
             var model = LearningModel.LoadFromFilePath(modelPath);
             var options = new LearningModelSessionOptions();
             SampleBasePage.SetModelNameForTelemetry("SqueezeNet", "AdapterSelection", model);
-            var session = new LearningModelSession(model, device, options);
+            new LearningModelSession(model, device, options);
         }
     }
 }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/AdapterSelection/AdapterSelection.xaml.cs
@@ -33,6 +33,8 @@ namespace WinMLSamplesGallery.Samples
 
             adapter_options.AddRange(adapters);
             AdapterListView.ItemsSource = adapter_options;
+
+            Task.Run(() => SetModelNameForTelemetry(device));
         }
 
         private void ChangeAdapter(object sender, RoutedEventArgs e)
@@ -99,6 +101,16 @@ namespace WinMLSamplesGallery.Samples
                 }
             }
             return adapters;
+        }
+
+        private void SetModelNameForTelemetry(LearningModelDevice device)
+        {
+            var modelName = "squeezenet1.1-7.onnx";
+            var modelPath = Path.Join(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, "Models", modelName);
+            var model = LearningModel.LoadFromFilePath(modelPath);
+            var options = new LearningModelSessionOptions();
+            SampleBasePage.SetModelNameForTelemetry("SqueezeNet", "AdapterSelection", model);
+            var session = new LearningModelSession(model, device, options);
         }
     }
 }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/Batching/Batching.xaml.cs
@@ -44,6 +44,7 @@ namespace WinMLSamplesGallery.Samples
             var modelName = "squeezenet1.1-7-batched.onnx";
             var modelPath = Path.Join(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, "Models", modelName);
             _model = LearningModel.LoadFromFilePath(modelPath);
+            SampleBasePage.SetModelNameForTelemetry("SqueezeNet", "Batching", _model);
         }
 
         async private void StartInference(object sender, RoutedEventArgs e)

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/EncryptedModel/EncryptedModel.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/EncryptedModel/EncryptedModel.xaml.cs
@@ -54,6 +54,7 @@ namespace WinMLSamplesGallery.Samples
             // The encrypted model (encrypted.onnx) is embedded as a resource in
             // the native binary: WinMLSamplesGalleryNative.dll.
             var inferenceModel = WinMLSamplesGalleryNative.EncryptedModels.LoadEncryptedResource(DecryptionKey.Password);
+            SampleBasePage.SetModelNameForTelemetry("Encrypted", "EncryptedModel", inferenceModel);
             var postProcessingModel = TensorizationModels.SoftMaxThenTopK(10);
 
             // Update the status

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageClassifier/ImageClassifier.xaml.cs
@@ -243,6 +243,8 @@ namespace WinMLSamplesGallery.Samples
             {
                 var modelPath = _modelDictionary[model];
                 var inferenceModel = LearningModel.LoadFromFilePath(modelPath);
+                SetModelNameForTelemetry(inferenceModel);
+
                 _inferenceSession = CreateLearningModelSession(inferenceModel);
 
                 var preProcessor = _preProcessorDictionary[model];
@@ -443,6 +445,14 @@ namespace WinMLSamplesGallery.Samples
         private void DeviceComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             TryPerformInference();
+        }
+
+        private void SetModelNameForTelemetry(LearningModel model)
+        {
+            var viewModel = (ClassifierViewModel)AllModelsGrid.SelectedItem;
+            var modelName = viewModel.Title;
+            var sampleName = "ImageClassifier";
+            SampleBasePage.SetModelNameForTelemetry(modelName, sampleName, model);
         }
     }
 }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageEffects/ImageEffects.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageEffects/ImageEffects.xaml.cs
@@ -364,6 +364,7 @@ namespace WinMLSamplesGallery.Samples
                 CloseModelOnSessionCreation = closeModel, // Close the model to prevent extra memory usage
                 BatchSizeOverride = 0
             };
+            SampleBasePage.SetModelNameForTelemetry("TensorizationModel", "ImageEffects", model);
             var session = new LearningModelSession(model, device, options);
             return session;
         }

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageSharpInterop/ImageSharpInterop.xaml.cs
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/Samples/ImageSharpInterop/ImageSharpInterop.xaml.cs
@@ -61,6 +61,7 @@ namespace WinMLSamplesGallery.Samples
             var inferenceModelName = "squeezenet1.1-7.onnx";
             var inferenceModelPath = Path.Join(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, "Models", inferenceModelName);
             var inferenceModel = LearningModel.LoadFromFilePath(inferenceModelPath);
+            SampleBasePage.SetModelNameForTelemetry("SqueezeNet", "ImageSharp", inferenceModel);
             _inferenceSession = CreateLearningModelSession(inferenceModel);
 
             var postProcessingModel = TensorizationModels.SoftMaxThenTopK(TopK);

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery/WinMLSamplesGallery.csproj
@@ -78,7 +78,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.1" />
+    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.11.0" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-stable" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative.Interop/WinMLSamplesGalleryNative.Interop.csproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative.Interop/WinMLSamplesGalleryNative.Interop.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.9.1" />
+    <PackageReference Include="Microsoft.AI.MachineLearning" Version="1.11.0" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
   </ItemGroup>
 
@@ -20,7 +20,7 @@
   <Target Name="GenerateProjection" BeforeTargets="DispatchToInnerBuilds;Build;CoreCompile">
     <ItemGroup>
       <WinMLSamplesGalleryNativeWinMDs Include="$(SolutionDir)WinMLSamplesGalleryNative\bin\neutral\WinMLSamplesGalleryNative.winmd" />
-      <WinMLSamplesGalleryNativeWinMDs Include="$(SolutionDir)packages\Microsoft.AI.MachineLearning.1.9.1\winmds\Microsoft.AI.MachineLearning.winmd" />
+      <WinMLSamplesGalleryNativeWinMDs Include="$(SolutionDir)packages\Microsoft.AI.MachineLearning.1.11.0\winmds\Microsoft.AI.MachineLearning.winmd" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.props" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.props')" />
   <Import Project="..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props')" />
-  <Import Project="..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -179,8 +179,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets')" />
     <Import Project="..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets')" />
+    <Import Project="..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.targets" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -188,10 +188,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.2\build\Microsoft.AI.DirectML.targets'))" />
   </Target>
   <Target Name="CopyNeutral" AfterTargets="Build">
     <Copy SourceFiles="$(OutDir)\WinMLSamplesGalleryNative.winmd" DestinationFolder="$(SolutionDir)$(MSBuildProjectName)\bin\neutral\WinMLSamplesGalleryNative.winmd" />

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.props" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.props')" />
-  <Import Project="..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.props" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.props')" />
+  <Import Project="..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props')" />
+  <Import Project="..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
@@ -179,8 +179,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.targets" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.targets')" />
-    <Import Project="..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.targets" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.targets')" />
+    <Import Project="..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets" Condition="Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets')" />
+    <Import Project="..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets" Condition="Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -188,10 +188,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210930.14\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.5.1\build\Microsoft.AI.DirectML.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.9.1\build\native\Microsoft.AI.MachineLearning.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.DirectML.1.8.0\build\Microsoft.AI.DirectML.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AI.MachineLearning.1.11.0\build\native\Microsoft.AI.MachineLearning.targets'))" />
   </Target>
   <Target Name="CopyNeutral" AfterTargets="Build">
     <Copy SourceFiles="$(OutDir)\WinMLSamplesGalleryNative.winmd" DestinationFolder="$(SolutionDir)$(MSBuildProjectName)\bin\neutral\WinMLSamplesGalleryNative.winmd" />

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.8.0" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.8.2" targetFramework="native" />
   <package id="Microsoft.AI.MachineLearning" version="1.11.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210930.14" targetFramework="native" />
 </packages>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AI.DirectML" version="1.5.1" targetFramework="native" />
-  <package id="Microsoft.AI.MachineLearning" version="1.9.1" targetFramework="native" />
+  <package id="Microsoft.AI.DirectML" version="1.8.0" targetFramework="native" />
+  <package id="Microsoft.AI.MachineLearning" version="1.11.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210930.14" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This PR updates the Samples Gallery to use the SetName experimental API to set model names inside samples. The updated model name contains the name of the sample in which the model was used (e.g. "SqueezeNet_ImageClassifier") so that when telemetry is sent during session creation, the usage of specific samples will be tracked.

- Samples Gallery is updated to use Microsoft.AI.MachineLearrning 1.11
- Uses SetName Experimental API: https://github.com/microsoft/onnxruntime/pull/10518