### PR TITLE
Add Updates for New Samples Gallery Release

### DIFF
--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/Package.appxmanifest
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="MicrosoftCorporationII.WindowsMLSamplesGallery"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="1.0.0.0" />
+    Version="1.0.7.0" />
 
   <Properties>
     <DisplayName>Windows ML Samples Gallery</DisplayName>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGallery (Package)/WinMLSamplesGallery (Package).wapproj
@@ -37,12 +37,18 @@
   <PropertyGroup>
     <ProjectGuid>dea7791f-55cf-4ed5-bc99-3870997b1242</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
-    <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>..\WinMLSamplesGallery\WinMLSamplesGallery.csproj</EntryPointProjectUniqueName>
+    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+    <PackageCertificateThumbprint>25067E5853327016828B1097611C6D97DAF9F5E8</PackageCertificateThumbprint>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <GenerateTestArtifacts>True</GenerateTestArtifacts>
+    <AppxBundlePlatforms>x86|x64|arm64</AppxBundlePlatforms>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
     <AppxBundle>Always</AppxBundle>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/TransformAsync.h
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/TransformAsync.h
@@ -220,7 +220,7 @@ public:
 #pragma endregion IMFAsyncCallback
 
 #pragma region IMFVideoSampleAllocatorNotify
-    HRESULT NotifyRelease();
+    HRESULT STDMETHODCALLTYPE NotifyRelease();
 #pragma endregion IMFVideoSampleAllocatorNotify
 
     // Uses the next available StreamModelBase to run inference on pInputSample 

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj
@@ -18,6 +18,10 @@
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Globals" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Microsoft_AI_DirectML_SkipLink>false</Microsoft_AI_DirectML_SkipLink>
+    <Microsoft_AI_DirectML_SkipIncludeDir>false</Microsoft_AI_DirectML_SkipIncludeDir>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|arm64">
@@ -63,7 +67,10 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PreferredToolArchitecture>x86</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -129,19 +136,21 @@
       <ConformanceMode Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ConformanceMode>
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdcpp20</LanguageStandard>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Default</LanguageStandard_C>
+      <ConformanceMode Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ConformanceMode>
+      <OmitFramePointers Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</OmitFramePointers>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Link>
-      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <!-- <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies> -->
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -154,9 +163,10 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Comctl32.lib;powrprof.lib;d3d11.lib;mf.lib;mfplat.lib;mfuuid.lib;shlwapi.lib;Gdi32.lib;Mfplat.lib;Mf.lib;Mfcore.lib;evr.lib;DXGI.lib;user32.lib;ole32.lib;d3d12.lib;dxgi.lib;d3dcompiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration Condition="'$(Configuration)|$(Platform)'=='Release|x64'">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)../WinMLSamplesGallery/Models/;$(MSBuildThisFileDirectory)../../build/native/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj.filters
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/WinMLSamplesGalleryNative.vcxproj.filters
@@ -1,181 +1,79 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="AdapterList.cpp" />
+    <ClCompile Include="Capture.cpp" />
+    <ClCompile Include="D3D12Quad.cpp" />
+    <ClCompile Include="DXResourceBinding.cpp" />
+    <ClCompile Include="EncryptedModels.cpp" />
+    <ClCompile Include="External\CSampleQueue.cpp" />
+    <ClCompile Include="External\utils.cpp" />
+    <ClCompile Include="OpenCVImage.cpp" />
+    <ClCompile Include="ORTHelpers.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-    <ClCompile Include="EncryptedModels.cpp">
-      <Filter>EncryptedModels</Filter>
-    </ClCompile>
-    <ClCompile Include="OpenCVImage.cpp">
-      <Filter>OpenCVInterop</Filter>
-    </ClCompile>
-    <ClCompile Include="StreamEffect.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="Capture.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="PreviewWnd.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="External\CSampleQueue.cpp" />
-    <ClCompile Include="SegmentModel.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync_IMFAsyncCallback.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync_IMFMediaEventGenerator.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync_IMFShutdown.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync_IMFTransform.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync_IMFVideoSampleAllocatorNotify.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="TransformAsync.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="External\utils.cpp">
-      <Filter>StreamEffect</Filter>
-    </ClCompile>
-    <ClCompile Include="AdapterList.cpp">
-      <Filter>AdapterList</Filter>
-    </ClCompile>
-    <ClCompile Include="DXResourceBinding.cpp">
-      <Filter>DXResourceBinding</Filter>
-    </ClCompile>
-    <ClCompile Include="ORTHelpers.cpp">
-      <Filter>DXResourceBinding</Filter>
-    </ClCompile>
-    <ClCompile Include="D3D12Quad.cpp">
-      <Filter>DXResourceBinding</Filter>
-    </ClCompile>
-    <ClCompile Include="Win32Application.cpp">
-      <Filter>DXResourceBinding</Filter>
-    </ClCompile>
+    <ClCompile Include="PreviewWnd.cpp" />
+    <ClCompile Include="SegmentModel.cpp" />
+    <ClCompile Include="StreamEffect.cpp" />
+    <ClCompile Include="TransformAsync.cpp" />
+    <ClCompile Include="TransformAsync_IMFAsyncCallback.cpp" />
+    <ClCompile Include="TransformAsync_IMFMediaEventGenerator.cpp" />
+    <ClCompile Include="TransformAsync_IMFShutdown.cpp" />
+    <ClCompile Include="TransformAsync_IMFTransform.cpp" />
+    <ClCompile Include="TransformAsync_IMFVideoSampleAllocatorNotify.cpp" />
+    <ClCompile Include="Win32Application.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h" />
-    <ClInclude Include="EncryptedModels.h">
-      <Filter>EncryptedModels</Filter>
-    </ClInclude>
-    <ClInclude Include="OpenCVImage.h">
-      <Filter>OpenCVInterop</Filter>
-    </ClInclude>
-    <ClInclude Include="RandomAccessStream.h">
-      <Filter>AbiHelpers</Filter>
-    </ClInclude>
-    <ClInclude Include="StreamEffect.h">
-      <Filter>StreamEffect</Filter>
-    </ClInclude>
-    <ClInclude Include="Capture.h">
-      <Filter>StreamEffect</Filter>
-    </ClInclude>
-    <ClInclude Include="common.h">
-      <Filter>StreamEffect</Filter>
-    </ClInclude>
-    <ClInclude Include="resource.h" />
-    <ClInclude Include="External\pch.h" />
+    <ClInclude Include="AdapterList.h" />
+    <ClInclude Include="Capture.h" />
+    <ClInclude Include="common.h" />
+    <ClInclude Include="D3D12Quad.h" />
+    <ClInclude Include="d3dx12.h" />
+    <ClInclude Include="DXResourceBinding.h" />
+    <ClInclude Include="EncryptedModels.h" />
     <ClInclude Include="External\common.h" />
     <ClInclude Include="External\CSampleQueue.h" />
     <ClInclude Include="External\logging.h" />
     <ClInclude Include="External\logmediatype.h" />
+    <ClInclude Include="External\pch.h" />
     <ClInclude Include="External\trace.h" />
-    <ClInclude Include="SegmentModel.h">
-      <Filter>StreamEffect</Filter>
-    </ClInclude>
-    <ClInclude Include="TransformAsync.h">
-      <Filter>StreamEffect</Filter>
-    </ClInclude>
-    <ClInclude Include="AdapterList.h">
-      <Filter>AdapterList</Filter>
-    </ClInclude>
-    <ClInclude Include="AdapterList.h">
-      <Filter>AdapterList</Filter>
-    </ClInclude>
-    <ClInclude Include="DXResourceBinding.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-    <ClInclude Include="d3dx12.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-    <ClInclude Include="stdafx.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-    <ClInclude Include="ORTHelpers.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-    <ClInclude Include="D3D12Quad.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-    <ClInclude Include="Win32Application.h">
-      <Filter>DXResourceBinding</Filter>
-    </ClInclude>
-<<<<<<< HEAD
+    <ClInclude Include="OpenCVImage.h" />
+    <ClInclude Include="ORTHelpers.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="RandomAccessStream.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="SegmentModel.h" />
+    <ClInclude Include="StreamEffect.h" />
+    <ClInclude Include="TransformAsync.h" />
+    <ClInclude Include="stdafx.h" />
     <ClInclude Include="WeakBuffer.h" />
-=======
->>>>>>> master
+    <ClInclude Include="Win32Application.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="shaders.hlsl" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="cat.jpg" />
+    <Image Include="hummingbird.jpg" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="WinMLSamplesGalleryNative.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="datafile.bin" />
+    <None Include="encrypted.onnx" />
+    <None Include="dx_preprocessor_efficient_net.onnx" />
     <None Include="packages.config" />
     <None Include="squeezenet1.1-7-batched.onnx" />
+    <None Include="squeezenet1.1-7.onnx" />
     <None Include="WinMLSamplesGalleryNative.def" />
     <None Include="PropertySheet.props" />
-    <None Include="encrypted.onnx" />
-    <None Include="squeezenet1.1-7.onnx">
-      <Filter>DXResourceBinding</Filter>
-    </None>
-    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime.dll" />
-    <None Include="dx_preprocessor_efficient_net.onnx">
-      <Filter>DXResourceBinding</Filter>
-    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\onnxruntime.dll" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="readme.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Filter Include="EncryptedModels">
-      <UniqueIdentifier>{bacd2f7a-1e95-444f-9447-25f28f21effe}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="OpenCVInterop">
-      <UniqueIdentifier>{c4ac812b-72fd-49d8-891b-a5764f445fc8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="AbiHelpers">
-      <UniqueIdentifier>{ed4f3871-4514-4b93-9ace-1315cad5491e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="AdapterList">
-      <UniqueIdentifier>{9df6a233-c2c6-4062-b738-31f7ba631acd}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="StreamEffect">
-      <UniqueIdentifier>{91675ea9-10e7-4490-af40-762311cf5ba9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="DXResourceBinding">
-      <UniqueIdentifier>{393a0b12-622a-4d4c-b4a6-ed0bb1b2e285}</UniqueIdentifier>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <Image Include="cat.jpg">
-      <Filter>DXResourceBinding</Filter>
-    </Image>
-    <Image Include="hummingbird.jpg">
-      <Filter>DXResourceBinding</Filter>
-    </Image>
-  </ItemGroup>
-  <ItemGroup>
-    <CustomBuild Include="shaders.hlsl">
-      <Filter>DXResourceBinding</Filter>
-    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
+++ b/Samples/WinMLSamplesGallery/WinMLSamplesGalleryNative/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Microsoft.AI.DirectML" version="1.9.0" targetFramework="native" />
   <package id="Microsoft.AI.MachineLearning" version="1.12.1" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220608.4" targetFramework="native" />
   <package id="directxtk12_desktop_2019" version="2022.5.10.1" targetFramework="native" />
   <package id="Microsoft.ML.OnnxRuntime.DirectML" version="1.12.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210930.14" targetFramework="native" />


### PR DESCRIPTION
This change adds a few updates for the new release of the Windows ML Samples Gallery
- Configuration changes are made to fix all release configuration build errors
- STDMETHODCALLTYPE is added to the function signature of NotifyRelease in TransformAsync.h to avoid "overriding virtual function differs by calling convention" errors