### PR TITLE
WinMLRunner add missing new line to output message after CPU fallback notification

### DIFF
--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -420,7 +420,7 @@ static DWORD FormatDataForCPUFallback(_In_ const PEVENT_RECORD EventRecord,
             static bool showOneWarningMessage = useGPU && !logCPUFallback;
             if (showOneWarningMessage)
             {
-                wprintf(L"WARNING: CPU fallback detected. Run again with -logCPUFallback to see which operators ran on the CPU.");
+                wprintf(L"WARNING: CPU fallback detected. Run again with -logCPUFallback to see which operators ran on the CPU.\n");
                 showOneWarningMessage = false;
             }
         }


### PR DESCRIPTION
When CPU fallback is detected, the line immediately following it appears jammed together. Line 417 has one, but 423 is missing it.

```
WARNING: CPU fallback detected. Run again with -logCPUFallback to see which operators ran on the CPU.Evaluating ...
```