### PR TITLE
remove trigger on pipeline for forked repos

### DIFF
--- a/azure-pipelines-samples.yml
+++ b/azure-pipelines-samples.yml
@@ -23,15 +23,6 @@ trigger:
     exclude:
     - Tools
 
-# PR validation trigger
-pr:
-  branches:
-    include:
-    - master
-  paths:
-    exclude:
-    - Tools
-
 jobs:
 - job: Public_Samples_Build
   timeoutInMinutes: 90


### PR DESCRIPTION
remove the trigger here, and then I can set the pipeline in our internal build to not trigger for forked repos.