### PR TITLE
Fix warnings as part of security wave 1

### DIFF
--- a/Tools/WinMLRunner/src/BindingUtilities.cpp
+++ b/Tools/WinMLRunner/src/BindingUtilities.cpp
@@ -653,7 +653,7 @@ namespace BindingUtilities
         {
             if (dim > 0)
             {
-                length *= dim;
+                length *= int(dim);
             }
         }
 

--- a/Tools/WinMLRunner/src/EventTraceHelper.cpp
+++ b/Tools/WinMLRunner/src/EventTraceHelper.cpp
@@ -30,7 +30,7 @@ static void RemoveTrailingSpace(PEVENT_MAP_INFO pMapInfo)
 
     for (DWORD i = 0; i < pMapInfo->EntryCount; i++)
     {
-        byteLength = (wcslen((LPWSTR)((PBYTE)pMapInfo + pMapInfo->MapEntryArray[i].OutputOffset)) - 1) * 2;
+        byteLength = DWORD(wcslen((LPWSTR)((PBYTE)pMapInfo + pMapInfo->MapEntryArray[i].OutputOffset)) - 1) * 2;
         *((LPWSTR)((PBYTE)pMapInfo + (pMapInfo->MapEntryArray[i].OutputOffset + byteLength))) = L'\0';
     }
 }


### PR DESCRIPTION
To compile WindowsAI with Werror and be more strict about warnings, we need to fix some warnings like these implicit type conversions